### PR TITLE
UART support and higher level API

### DIFF
--- a/Estee_TMC5130.cpp
+++ b/Estee_TMC5130.cpp
@@ -41,8 +41,8 @@ bool Estee_TMC5130::begin( uint8_t ihold, uint8_t irun, MotorDirection stepper_d
 {
 	// set initial currents and delay
 	TMC5130_Reg::IHOLD_IRUN_Register iholdrun = { 0 };
-	iholdrun.ihold = ihold;
-	iholdrun.irun = irun;
+	iholdrun.ihold = constrain(ihold, 0, 31);
+	iholdrun.irun = constrain(irun, 0, 31);
 	iholdrun.iholddelay = 7;
 	writeRegister(TMC5130_Reg::IHOLD_IRUN, iholdrun.value);
 

--- a/Estee_TMC5130.cpp
+++ b/Estee_TMC5130.cpp
@@ -49,17 +49,27 @@ bool Estee_TMC5130::begin( uint8_t ihold, uint8_t irun, MotorDirection stepper_d
 	// use position mode
 	setRampMode(POSITIONING_MODE);
 
-	// set chopper config
-	TMC5130_Reg::CHOPCONF_Register chopconf = { 0 };
-	chopconf.toff = 5;
-	chopconf.hend_offset = 1;
-	chopconf.tbl = 0b10;
-	writeRegister(TMC5130_Reg::CHOPCONF, chopconf.value);
-
 	TMC5130_Reg::GCONF_Register gconf = { 0 };
-	gconf.en_pwm_mode = true;
+	gconf.en_pwm_mode = true; //Enable stealthChop PWM mode
 	gconf.shaft = stepper_direction;
 	writeRegister(TMC5130_Reg::GCONF, gconf.value);
+
+	// Recommended settings in quick config guide
+	TMC5130_Reg::PWMCONF_Register pwmconf = { 0 };
+	pwmconf.pwm_autoscale = true;
+	pwmconf.pwm_grad = 1;
+	pwmconf.pwm_ampl = 255;
+	pwmconf.pwm_freq = 0b01; // recommended : 35kHz with internal typ. 13.2MHZ clock. 0b01 => 2/683 * f_clk = 38653Hz
+	writeRegister(TMC5130_Reg::PWMCONF, pwmconf.value);
+
+	// Recommended settings in quick config guide
+	TMC5130_Reg::CHOPCONF_Register chopconf = { 0 };
+	chopconf.toff = 4;
+	chopconf.tbl = 0b10;
+	chopconf.hstrt_tfd = 4;
+	chopconf.hend_offset = 0;
+	writeRegister(TMC5130_Reg::CHOPCONF, chopconf.value);
+
 
 	return false;
 }

--- a/Estee_TMC5130.cpp
+++ b/Estee_TMC5130.cpp
@@ -126,17 +126,30 @@ void Estee_TMC5130::setRampMode(Estee_TMC5130::RampMode mode)
 
 long Estee_TMC5130::getCurrentPosition()
 {
-	return readRegister(TMC5130_Reg::XACTUAL) / _uStepCount;
+	uint32_t uStepPos = readRegister(TMC5130_Reg::XACTUAL);
+
+	if (uStepPos == 0xFFFFFFFF)
+		return NAN;
+	else
+		return (int)uStepPos / _uStepCount;
 }
 
 long Estee_TMC5130::getTargetPosition()
 {
-	return readRegister(TMC5130_Reg::XTARGET) / _uStepCount;
+	uint32_t uStepPos = readRegister(TMC5130_Reg::XTARGET);
+
+	if (uStepPos == 0xFFFFFFFF)
+		return NAN;
+	else
+		return (int)uStepPos / _uStepCount;
 }
 
 float Estee_TMC5130::getCurrentSpeed()
 {
 	uint32_t data = readRegister(TMC5130_Reg::VACTUAL);
+
+	if (data == 0xFFFFFFFF)
+		return NAN;
 
 	// Returned data is 24-bits, signed => convert to 32-bits, signed.
 	if (bitRead(data, 23)) // highest bit set => negative value

--- a/Estee_TMC5130.cpp
+++ b/Estee_TMC5130.cpp
@@ -290,7 +290,7 @@ bool Estee_TMC5130::setEncoderResolution(int motorSteps, int encResolution, bool
 		int decimalPart = (int)((factor - (float)integerPart) * 10000.0f);
 		if (inverted)
 		{
-			integerPart = -integerPart;
+			integerPart = 65535 - integerPart;
 			decimalPart = 10000 - decimalPart;
 		}
 		int32_t encConst =  integerPart * 65536 + decimalPart;

--- a/Estee_TMC5130.cpp
+++ b/Estee_TMC5130.cpp
@@ -47,14 +47,7 @@ bool Estee_TMC5130::begin( uint8_t ihold, uint8_t irun, MotorDirection stepper_d
 	writeRegister(TMC5130_Reg::IHOLD_IRUN, iholdrun.value);
 
 	// use position mode
-	writeRegister(TMC5130_Reg::RAMPMODE, TMC5130_Reg::POSITIONING_MODE);
-
-	// set ramp curves
-	//writeRegister(TMC5130_Reg::A_1, 0xffff );
-	writeRegister(TMC5130_Reg::V_1, 0x0 ); // disable A1 & D1 in position mode, amax, vmax only
-	writeRegister(TMC5130_Reg::AMAX, 0xffff );
-	writeRegister(TMC5130_Reg::VMAX, 0xffff );
-	//writeRegister(TMC5130_Reg::DMAX, 0xffff );
+	setRampMode(POSITIONING_MODE);
 
 	// set chopper config
 	TMC5130_Reg::CHOPCONF_Register chopconf = { 0 };
@@ -84,8 +77,9 @@ float Estee_TMC5130::updateFrequencyScaling()
 	int32_t vmax = 10000;
 	int32_t dt_ms = 100;
 
-	writeRegister(TMC5130_Reg::VMAX, 0);
-	writeRegister(TMC5130_Reg::RAMPMODE, TMC5130_Reg::VELOCITY_MODE_POS);
+	//TODO disable driver
+
+	setRampMode(VELOCITY_MODE);
 	writeRegister(TMC5130_Reg::AMAX, 60000);
 	writeRegister(TMC5130_Reg::VMAX, vmax);
 	int32_t xactual1 = readRegister(TMC5130_Reg::XACTUAL);
@@ -93,6 +87,92 @@ float Estee_TMC5130::updateFrequencyScaling()
 	int32_t xactual2 = readRegister(TMC5130_Reg::XACTUAL);
 	writeRegister(TMC5130_Reg::VMAX,0);	// halt
 
+	//TODO re-enable driver
+
 	// scaling factor
 	return (vmax * (dt_ms/1000.0)) / (xactual2 - xactual1);
+}
+
+void Estee_TMC5130::setRampMode(Estee_TMC5130::RampMode mode)
+{
+	switch (mode)
+	{
+		case POSITIONING_MODE:
+		writeRegister(TMC5130_Reg::RAMPMODE, TMC5130_Reg::POSITIONING_MODE);
+		break;
+
+		case VELOCITY_MODE:
+		setMaxSpeed(0); // There is no way to know if we should move in the positive or negative direction => set speed to 0.
+		writeRegister(TMC5130_Reg::RAMPMODE, TMC5130_Reg::VELOCITY_MODE_POS);
+		break;
+
+		case HOLD_MODE:
+		writeRegister(TMC5130_Reg::RAMPMODE, TMC5130_Reg::HOLD_MODE);
+		break;
+	}
+
+	_currentRampMode = mode;
+}
+
+long Estee_TMC5130::getCurrentPosition()
+{
+	return readRegister(TMC5130_Reg::XACTUAL) / _uStepCount;
+}
+
+long Estee_TMC5130::getTargetPosition()
+{
+	return readRegister(TMC5130_Reg::XTARGET) / _uStepCount;
+}
+
+float Estee_TMC5130::getCurrentSpeed()
+{
+	uint32_t data = readRegister(TMC5130_Reg::VACTUAL);
+
+	// Returned data is 24-bits, signed => convert to 32-bits, signed.
+	if (bitRead(data, 23)) // highest bit set => negative value
+		data |= 0xFF000000;
+
+	return speedToHz(data);
+}
+
+void Estee_TMC5130::setCurrentPosition(long position)
+{
+	writeRegister(TMC5130_Reg::XACTUAL, position * _uStepCount);
+}
+
+void Estee_TMC5130::setTargetPosition(long position)
+{
+	writeRegister(TMC5130_Reg::XTARGET, position * _uStepCount);
+}
+
+void Estee_TMC5130::setMaxSpeed(float speed)
+{
+	writeRegister(TMC5130_Reg::VMAX, speedFromHz(abs(speed)));
+
+	if (_currentRampMode == VELOCITY_MODE)
+	{
+		writeRegister(TMC5130_Reg::RAMPMODE, speed < 0.0f ? TMC5130_Reg::VELOCITY_MODE_NEG : TMC5130_Reg::VELOCITY_MODE_POS);
+	}
+}
+
+void Estee_TMC5130::setRampSpeeds(float startSpeed, float stopSpeed, float transitionSpeed)
+{
+	writeRegister(TMC5130_Reg::VSTART, speedFromHz(abs(startSpeed)));
+	writeRegister(TMC5130_Reg::VSTOP, speedFromHz(abs(stopSpeed)));
+	writeRegister(TMC5130_Reg::V_1, speedFromHz(abs(transitionSpeed)));
+}
+
+void Estee_TMC5130::setAccelerations(float maxAccel, float maxDecel, float startAccel, float finalDecel)
+{
+	writeRegister(TMC5130_Reg::AMAX, accelFromHz(abs(maxAccel)));
+	writeRegister(TMC5130_Reg::DMAX, accelFromHz(abs(maxDecel)));
+	writeRegister(TMC5130_Reg::A_1, accelFromHz(abs(startAccel)));
+	writeRegister(TMC5130_Reg::D_1, accelFromHz(abs(finalDecel)));
+}
+
+void Estee_TMC5130::stop()
+{
+	// §14.2.4 Early Ramp Termination option b)
+	writeRegister(TMC5130_Reg::VSTART, 0);
+	writeRegister(TMC5130_Reg::VMAX, 0);
 }

--- a/Estee_TMC5130.cpp
+++ b/Estee_TMC5130.cpp
@@ -307,7 +307,7 @@ bool Estee_TMC5130::setEncoderResolution(int motorSteps, int encResolution, bool
 #endif
 
 		//Check if the decimal prescaler gives an exact match. Floats have about 7 digits of precision so no worries here.
-		return ((int)(factor * 10000.0f) * encResolution == motorSteps * _uStepCount * 10000);
+		return ((int)(factor * 10000.0f) * encResolution == motorSteps * (int)_uStepCount * 10000);
 	}
 }
 

--- a/Estee_TMC5130.cpp
+++ b/Estee_TMC5130.cpp
@@ -82,6 +82,10 @@ void Estee_TMC5130::end()
 	; // FIXME: try and shutdown motor/chips?
 }
 
+bool Estee_TMC5130::isLastReadSuccessful()
+{
+	return _lastRegisterReadSuccess;
+}
 
 // From "28.1 Using the Internal Clock", how to figure out the step/sec scaling value
 float Estee_TMC5130::updateFrequencyScaling()

--- a/Estee_TMC5130.cpp
+++ b/Estee_TMC5130.cpp
@@ -206,3 +206,10 @@ void Estee_TMC5130::stop()
 	writeRegister(TMC5130_Reg::VSTART, 0);
 	writeRegister(TMC5130_Reg::VMAX, 0);
 }
+
+void Estee_TMC5130::setModeChangeSpeeds(float pwmThrs, float coolThrs, float highThrs)
+{
+	writeRegister(TMC5130_Reg::TPWMTHRS, thrsSpeedToTstep(pwmThrs));
+	writeRegister(TMC5130_Reg::TCOOLTHRS, thrsSpeedToTstep(coolThrs));
+	writeRegister(TMC5130_Reg::THIGH, thrsSpeedToTstep(highThrs));
+}

--- a/Estee_TMC5130.cpp
+++ b/Estee_TMC5130.cpp
@@ -70,6 +70,8 @@ bool Estee_TMC5130::begin( uint8_t ihold, uint8_t irun, MotorDirection stepper_d
 	chopconf.hend_offset = 0;
 	writeRegister(TMC5130_Reg::CHOPCONF, chopconf.value);
 
+	//Set default start, stop, threshold speeds.
+	setRampSpeeds(0, 0.1, 0); //Start, stop, threshold speeds
 
 	return false;
 }
@@ -183,6 +185,11 @@ void Estee_TMC5130::setRampSpeeds(float startSpeed, float stopSpeed, float trans
 	writeRegister(TMC5130_Reg::VSTART, speedFromHz(abs(startSpeed)));
 	writeRegister(TMC5130_Reg::VSTOP, speedFromHz(abs(stopSpeed)));
 	writeRegister(TMC5130_Reg::V_1, speedFromHz(abs(transitionSpeed)));
+}
+
+void Estee_TMC5130::setAcceleration(float maxAccel)
+{
+	setAccelerations(maxAccel, maxAccel, maxAccel, maxAccel);
 }
 
 void Estee_TMC5130::setAccelerations(float maxAccel, float maxDecel, float startAccel, float finalDecel)

--- a/Estee_TMC5130.h
+++ b/Estee_TMC5130.h
@@ -153,6 +153,10 @@ public:
 
 	void setCommunicationMode(CommunicationMode mode);
 
+	/* Register read / write statistics */
+	void resetCommunicationSuccessRate();
+	float getReadSuccessRate();
+	float getWriteSuccessRate();
 protected:
 	const uint8_t NB_RETRIES_READ = 3;
 	const uint8_t NB_RETRIES_WRITE = 3;
@@ -161,6 +165,13 @@ protected:
 	uint8_t _slaveAddress;
 	CommunicationMode _currentMode;
 	uint8_t _transmissionCounter;
+
+	/* Read / write fail statistics */
+	uint32_t _readAttemptsCounter;
+	uint32_t _readSuccessfulCounter;
+	uint32_t _writeAttemptsCounter;
+	uint32_t _writeSuccessfulCounter;
+
 
 	virtual void beginTransmission() {}
 	virtual void endTransmission() {}

--- a/Estee_TMC5130.h
+++ b/Estee_TMC5130.h
@@ -142,12 +142,12 @@ private:
 
 	// Following §14.1 Real world unit conversions
 	// v[Hz] = v[5130A] * ( f CLK [Hz]/2 / 2^23 )
-	float speedToHz(long speedInternal) { return ((float)speedInternal * (float)_fclk / (float)(1 << 24) / (float)_uStepCount); }
-	long speedFromHz(float speedHz) { return (long)(speedHz / ((float)_fclk / (float)(1 << 24)) * (float)_uStepCount); }
+	float speedToHz(long speedInternal) { return ((float)speedInternal * (float)_fclk / (float)(1ul << 24) / (float)_uStepCount); }
+	long speedFromHz(float speedHz) { return (long)(speedHz / ((float)_fclk / (float)(1ul << 24)) * (float)_uStepCount); }
 
 	// Following §14.1 Real world unit conversions
 	// a[Hz/s] = a[5130A] * f CLK [Hz]^2 / (512*256) / 2^24
-	long accelFromHz(float accelHz) { return (long)(accelHz / ((float)_fclk * (float)_fclk / (512.0*256.0) / (float)(1<<24)) * (float)_uStepCount); }
+	long accelFromHz(float accelHz) { return (long)(accelHz / ((float)_fclk * (float)_fclk / (512.0*256.0) / (float)(1ul << 24)) * (float)_uStepCount); }
 
 	// See §12 Velocity based mode control
 	long thrsSpeedToTstep(float thrsSpeed) { return thrsSpeed != 0.0 ? (long)constrain((float)_fclk / (thrsSpeed * 256.0), 0, 1048575) : 0; }

--- a/Estee_TMC5130.h
+++ b/Estee_TMC5130.h
@@ -66,7 +66,8 @@ public:
 	void setTargetPosition(long position); // Set the target position /!\ Set all other motion profile parameters before
 	void setMaxSpeed(float speed); // Set the max speed VMAX (steps/second)
 	void setRampSpeeds(float startSpeed, float stopSpeed, float transitionSpeed); // Set the ramp start speed VSTART, ramp stop speed VSTOP, acceleration transition speed V1 (steps / second). /!\ Set VSTOP >= VSTART, VSTOP >= 0.1
-	void setAccelerations(float maxAccel, float maxDecel, float startAccel, float finalDecel); // Set the ramp accelerations AMAX, DMAX, A1, D1 (steps / second^2)
+	void setAcceleration(float maxAccel); // Set the ramp acceleration / deceleration (steps / second^2)
+	void setAccelerations(float maxAccel, float maxDecel, float startAccel, float finalDecel); // Set the ramp accelerations AMAX, DMAX, A1, D1 (steps / second^2) /!\ Do not set startAccel, finalDecel to 0 even if transitionSpeed = 0
 
 	void stop(); // Stop the current motion according to the set ramp mode and motion parameters. The max speed and start speed are set to 0 but the target position stays unchanged.
 

--- a/Estee_TMC5130.h
+++ b/Estee_TMC5130.h
@@ -141,6 +141,7 @@ public:
 	void resetCommunication(); // Reset communication with TMC5130 : pause activity on the serial bus.
 
 	void setSlaveAddress(uint8_t slaveAddress, bool NAI=true); // Set the slave address register. Take into account the TMC5130 NAI input (default to high). Range : 0 - 253 if NAI is low, 1 - 254 if NAI is high.
+	uint8_t getSlaveAddress() { return _slaveAddress; }
 
 	//TODO add optional internal checks (reg write counter, retry in case of bad CRC)
 

--- a/Estee_TMC5130.h
+++ b/Estee_TMC5130.h
@@ -37,7 +37,7 @@ public:
 	enum MotorDirection { NORMAL_MOTOR_DIRECTION =	0x00, INVERSE_MOTOR_DIRECTION = 0x1 };
 	enum RampMode { POSITIONING_MODE, VELOCITY_MODE, HOLD_MODE };
 
-	Estee_TMC5130(uint32_t fclk=DEFAULT_F_CLK);
+	Estee_TMC5130(uint32_t fclk = DEFAULT_F_CLK);
 	~Estee_TMC5130();
 
 	// start/stop this module
@@ -77,7 +77,7 @@ protected:
 private:
 	uint32_t _fclk;
 	RampMode _currentRampMode;
-	const uint16_t _uStepCount = 256; // Number of microsteps per step
+	static constexpr uint16_t _uStepCount = 256; // Number of microsteps per step
 
 	// Following §14.1 Real world unit conversions
 	// v[Hz] = v[5130A] * ( f CLK [Hz]/2 / 2^23 )
@@ -96,9 +96,9 @@ private:
 class Estee_TMC5130_SPI : public Estee_TMC5130 {
 public:
 	Estee_TMC5130_SPI( uint8_t chipSelectPin,	// pin to use for the SPI bus SS line
-		uint32_t fclk=DEFAULT_F_CLK,
-		const SPISettings &spiSettings=SPISettings(1000000, MSBFIRST, SPI_MODE0), // spi bus settings to use
-		SPIClass& spi=SPI ); // spi class to use
+		uint32_t fclk = DEFAULT_F_CLK,
+		const SPISettings &spiSettings = SPISettings(1000000, MSBFIRST, SPI_MODE0), // spi bus settings to use
+		SPIClass& spi = SPI ); // spi class to use
 
 	uint32_t readRegister(uint8_t address);	// addresses are from TMC5130.h
 	uint8_t  writeRegister(uint8_t address, uint32_t data);
@@ -107,7 +107,7 @@ public:
 private:
 	uint8_t _CS;
 	SPISettings _spiSettings;
-	SPIClass &_spi;
+	SPIClass *_spi;
 
 	void _beginTransaction();
 	void _endTransaction();
@@ -137,9 +137,9 @@ public:
 	enum CommunicationMode {RELIABLE_MODE, STREAMING_MODE};
 
 
-	Estee_TMC5130_UART(Stream& serial=Serial, // Serial port to use
+	Estee_TMC5130_UART(Stream& serial = Serial, // Serial port to use
 		uint8_t slaveAddress = 0, // TMC5130 slave address (default 0 if NAI is low, 1 if NAI is high)
-		uint32_t fclk=DEFAULT_F_CLK);
+		uint32_t fclk = DEFAULT_F_CLK);
 
 	uint32_t readRegister(uint8_t address, ReadStatus *status);	// addresses are from TMC5130.h. Pass an optional status pointer to detect failures.
 	uint32_t readRegister(uint8_t address) { return readRegister(address, nullptr); }
@@ -158,10 +158,10 @@ public:
 	float getReadSuccessRate();
 	float getWriteSuccessRate();
 protected:
-	const uint8_t NB_RETRIES_READ = 3;
-	const uint8_t NB_RETRIES_WRITE = 3;
+	static constexpr uint8_t NB_RETRIES_READ = 3;
+	static constexpr uint8_t NB_RETRIES_WRITE = 3;
 
-	Stream &_serial;
+	Stream *_serial;
 	uint8_t _slaveAddress;
 	CommunicationMode _currentMode;
 	uint8_t _transmissionCounter;
@@ -180,7 +180,7 @@ protected:
 	void _writeReg(uint8_t address, uint32_t data);
 
 private:
-	const uint8_t SYNC_BYTE = 0x05;
+	static constexpr uint8_t SYNC_BYTE = 0x05;
 
 	void computeCrc(uint8_t *datagram, uint8_t datagramLength);
 };
@@ -201,10 +201,10 @@ private:
  */
 class Estee_TMC5130_UART_Transceiver : public Estee_TMC5130_UART {
 public:
-	Estee_TMC5130_UART_Transceiver(uint8_t txEnablePin, // pin to enable transmission on the external transceiver
-		Stream& serial=Serial, // Serial port to use
+	Estee_TMC5130_UART_Transceiver(uint8_t txEnablePin = -1, // pin to enable transmission on the external transceiver
+		Stream& serial = Serial, // Serial port to use
 		uint8_t slaveAddress = 0, // TMC5130 slave address (default 0 if NAI is low, 1 if NAI is high)
-		uint32_t fclk=DEFAULT_F_CLK)
+		uint32_t fclk = DEFAULT_F_CLK)
 	: Estee_TMC5130_UART(serial, slaveAddress, fclk), _txEn(txEnablePin)
 	{
 		pinMode(_txEn, OUTPUT);
@@ -218,7 +218,7 @@ protected:
 
 	void endTransmission()
 	{
-		_serial.flush();
+		_serial->flush();
 		digitalWrite(_txEn, LOW);
 	}
 

--- a/Estee_TMC5130.h
+++ b/Estee_TMC5130.h
@@ -90,17 +90,21 @@ private:
  */
 class Estee_TMC5130_UART : public Estee_TMC5130 {
 public:
+	/* Read register return codes */
+	enum ReadStatus {SUCCESS, NO_REPLY, BAD_CRC};
+
 	Estee_TMC5130_UART(Stream& serial=Serial, // Serial port to use
 		uint8_t slaveAddress = 0, // TMC5130 slave address (default 0 if NAI is low, 1 if NAI is high)
 		uint32_t fclk=F_CPU);
 
-	uint32_t readRegister(uint8_t address);	// addresses are from TMC5130.h
-	//TODO read operation status
+	uint32_t readRegister(uint8_t address, ReadStatus *status);	// addresses are from TMC5130.h. Pass an optional status pointer to detect failures.
+	uint32_t readRegister(uint8_t address) { return readRegister(address, nullptr); }
 	uint8_t  writeRegister(uint8_t address, uint32_t data);
 
 	void setSlaveAddress(uint8_t slaveAddress);
 
 	//TODO handle communication reset ?
+	//TODO add optional internal checks (reg write counter, retry in case of bad CRC)
 
 
 protected:

--- a/Estee_TMC5130.h
+++ b/Estee_TMC5130.h
@@ -28,14 +28,19 @@ SOFTWARE.
 
 #include <Arduino.h>
 #include <SPI.h>
+#include <Estee_TMC5130_registers.h>
 
 class Estee_TMC5130 {
 public:
+	static constexpr uint8_t IC_VERSION = 0x11;
+
+	enum MotorDirection { NORMAL_MOTOR_DIRECTION =	0x00, INVERSE_MOTOR_DIRECTION = 0x1 };
+
 	Estee_TMC5130(uint32_t fclk=F_CPU);
 	~Estee_TMC5130();
 
 	// start/stop this module
-	bool begin(uint8_t ihold, uint8_t irun, uint8_t stepper_direction/*=NORMAL_MOTOR_DIRECTION*/);
+	bool begin(uint8_t ihold, uint8_t irun, MotorDirection stepper_direction/*=NORMAL_MOTOR_DIRECTION*/);
 	void end();
 
 	virtual uint32_t readRegister(uint8_t address) = 0;	// addresses are from TMC5130.h
@@ -47,6 +52,9 @@ public:
 
 	// high level interface
 	void setRampCurves() {}
+
+protected:
+	static constexpr uint8_t WRITE_ACCESS = 0x80;	//Register write access for spi / uart communication
 
 private:
 	uint32_t _fclk;
@@ -162,175 +170,5 @@ private:
 	uint8_t _txEn;
 };
 
-
-// TRINAMIC TMC5130 Register Address Defines
-#define GCONF				0x00 	//Global configuration flags
-#define X_COMPARE 			0x05	//Position  comparison  register
-#define IHOLD_IRUN			0x10	//Driver current control
-#define TCOOLTHRS			0x14	//This is the lower threshold velocity for switching on smart energy coolStep and stallGuard feature.
-#define RAMPMODE			0x20	//Driving mode (Velocity, Positioning, Hold)
-
-// q & qdot (position, velocity)
-#define XACTUAL				0x21	//Actual motor position
-#define VACTUAL 			0x22	//Actual  motor  velocity  from  ramp  generator
-
-// Ramp curves
-#define VSTART				0x23	//Motor start velocity
-#define A_1					0x24	//First  acceleration  between  VSTART  and  V1
-#define V_1					0x25	//First  acceleration  /  deceleration  phase  target velocity
-#define AMAX				0x26	//Second  acceleration  between  V1  and  VMAX
-#define VMAX 				0x27	//This is the target velocity in velocity mode. It can be changed any time during a motion.
-#define DMAX				0x28	//Deceleration between VMAX and V1
-#define D_1					0x2A 	//Deceleration  between  V1  and  VSTOP
-									//Attention:  Do  not  set  0  in  positioning  mode, even if V1=0!
-#define VSTOP				0x2B	//Motor stop velocity (unsigned)
-									//Attention: Set VSTOP > VSTART!
-									//Attention:  Do  not  set  0  in  positioning  mode, minimum 10 recommend!
-#define TZEROWAIT			0x2C	//Defines  the  waiting  time  after  ramping  down
-									//to  zero  velocity  before  next  movement  or
-									//direction  inversion  can  start.  Time  range  is about 0 to 2 seconds.
-
-#define XTARGET				0x2D	//Target position for ramp mode
-#define SW_MODE 			0x34	//Switch mode configuration
-#define RAMP_STAT			0x35	//Ramp status and switch event status
-#define XLATCH				0x36	//Latches  XACTUAL  upon  a programmable switch event
-
-
-#define CHOPCONF			0x6C	//Chopper and driver configuration
-#define 	DISS2G(n)		(((n)&0x1)<<30)	// Short to GND protection is on=1,disabled=0
-#define 	DEDGE(n)		(((n)&0x1)<<29) // 1: Enable step impulse at each step edge to reduce step frequency requirement
-#define 	INTPOL(n)		(((n)&0x1)<<28) // 1: The actual microstep resolution (MRES) becomes extrapolated to
-											// 256 microsteps for smoothest motor operation (useful for Step/Dir operation, only)
-#define 	MRES(n)			(((n)&0xF)<<24) // %0000: Native 256 microstep setting. Normally use this setting
-											// with the internal motion controller.
-											// %0001 … %1000:
-											// 128, 64, 32, 16, 8, 4, 2, FULLSTEP
-											// Reduced microstep resolution esp. for Step/Dir operation.
-											// The resolution gives the number of microstep entries per
-											// sine quarter wave.
-											// The driver automatically uses microstep positions which
-											// result in a symmetrical wave, when choosing a lower
-											// microstep resolution.
-											// step width=2^MRES [microsteps]
-#define 	SYNC(n)			(((n)&0xF)<<20) // This register allows synchronization of the chopper for
-											// both phases of a two phase motor in order to avoid the
-											// occurrence of a beat, especially at low motor velocities. It
-											// is automatically switched off above VHIGH.
-											// %0000: Chopper sync function chopSync off
-											// %0001 … %1111:
-											// Synchronization with fSYNC = fCLK/(sync*64)
-											// Hint: Set TOFF to a low value, so that the chopper cycle is
-											// ended, before the next sync clock pulse occurs. Set for the
-											// double desired chopper frequency for chm=0, for the
-											// desired base chopper frequency for chm=1
-#define 	VHIGHCHM(n)		(((n)&0x1)<<19) // This bit enables switching to chm=1 and fd=0, when VHIGH
-											// is exceeded. This way, a higher velocity can be achieved.
-											// Can be combined with vhighfs=1. If set, the TOFF setting
-											// automatically becomes doubled during high velocity
-											// operation in order to avoid doubling of the chopper
-											// frequency.
-#define 	VHIGHFS(n)		(((n)&0x1)<<18) // This bit enables switching to fullstep, when VHIGH is
-											// exceeded. Switching takes place only at 45° position.
-											// The fullstep target current uses the current value from
-											// the microstep table at the 45° position.
-#define 	VSENSE(n)		(((n)&0x1)<<17) //0: Low sensitivity, high sense resistor voltage
-											//1: High sensitivity, low sense resistor voltage
-#define 	TBL(n)			(((n)&0x3)<<15) // %00 … %11:
-											// Set comparator blank time to 16, 24, 36 or 54 clocks
-											// Hint: %01 or %10 is recommended for most applications
-#define 	CHM(n)			(((n)&0x1)<<14) // 0 Standard mode (spreadCycle)
-											// 1 Constant off time with fast decay time.
-											// Fast decay time is also terminated when the
-											// negative nominal current is reached. Fast decay is
-											// after on time.
-#define 	RNDTF(n)		(((n)&0x1)<<13) // 0 Chopper off time is fixed as set by TOFF
-											// 1 Random mode, TOFF is random modulated by
-											// dNCLK= -12 … +3 clocks.
-#define 	DISFDCC(n)		(((n)&0x1)<<12) // chm=1:
-											// disfdcc=1 disables current comparator usage for termination
-											// of the fast decay cycle
-#define 	TFD3(n)			(((n)&0x1)<<11) // chm=1: MSB of fast decay time setting TFD[3]
-#define 	HEND(n)			(((n)&0xF)<<7)  // chm=0 %0000 … %1111:
-											// Hysteresis is -3, -2, -1, 0, 1, …, 12
-											// (1/512 of this setting adds to current setting)
-											// This is the hysteresis value which becomes
-											// used for the hysteresis chopper.
-											// chm=1 %0000 … %1111:
-											// Offset is -3, -2, -1, 0, 1, …, 12
-											// This is the sine wave offset and 1/512 of the
-											// value becomes added to the absolute value
-											// of each sine wave entry.
-#define 	HSTRT_TFD(n)	(((n)&0x7)<<4)  // chm=0 %000 … %111:
-											// Add 1, 2, …, 8 to hysteresis low value HEND
-											// (1/512 of this setting adds to current setting)
-											// Attention: Effective HEND+HSTRT ≤ 16.
-											// Hint: Hysteresis decrement is done each 16
-											// clocks
-
-											// TFD [2..0]
-											// fast decay time setting
-											// chm=1 Fast decay time setting (MSB: tfd3):
-											// %0000 … %1111:
-											// Fast decay time setting TFD with
-											// NCLK= 32*HSTRT (%0000: slow decay only)
-#define 	TOFF(n)			(((n)&0xF)<<0)  // Off time setting controls duration of slow decay phase
-											// NCLK= 12 + 32*TOFF
-											// %0000: Driver disable, all bridges off
-											// %0001: 1 – use only with TBL ≥ 2
-											// %0010 … %1111: 2 … 15
-
-#define COOLCONF			0x6D	//coolStep smart current control register and stallGuard2 configuration
-#define 	SFILT(n)		(((n)&0x1)<<24) // 0 Standard mode, high time resolution for
-											// stallGuard2
-											// 1 Filtered mode, stallGuard2 signal updated for each
-											// four fullsteps (resp. six fullsteps for 3 phase motor)
-											// only to compensate for motor pole tolerances
-#define 	SGT(n)			(((n)&0x7F)<<16)// This signed value controls stallGuard2 level for stall
-											// output and sets the optimum measurement range for
-											// readout. A lower value gives a higher sensitivity. Zero is
-											// the starting value working with most motors.
-											// -64 to +63: A higher value makes stallGuard2 less
-											// sensitive and requires more torque to
-											// indicate a stall.
-#define 	SEIMIN(n)		(((n)&0x1)<<15) // 0: 1/2 of current setting (IRUN)
-											// 1: 1/4 of current setting (IRUN)
-#define 	SEDN(n)			(((n)&0x3)<<13) // %00: For each 32 stallGuard2 values decrease by one
-											// %01: For each 8 stallGuard2 values decrease by one
-											// %10: For each 2 stallGuard2 values decrease by one
-											// %11: For each stallGuard2 value decrease by one
-#define 	SEMAX(n)		(((n)&0xF)<<8)  // If the stallGuard2 result is equal to or above
-											// (SEMIN+SEMAX+1)*32, the motor current becomes
-											// decreased to save energy.
-											// %0000 … %1111: 0 … 15
-#define 	SEUP(n)			(((n)&0x3)<<5)  // Current increment steps per measured stallGuard2 value %00 … %11: 1, 2, 4, 8
-#define 	SEMIN(n)		(((n)&0xF)<<0)  // If the stallGuard2 result falls below SEMIN*32, the motor
-											// current becomes increased to reduce motor load angle.
-											// %0000: smart current control coolStep off
-											// %0001 … %1111: 1 … 15
-
-#define DRV_STATUS 			0x6F	// stallGuard2 value and driver error flags
-
-#define SET_IHOLDDELAY(n)	(((n)&0xF)<<16)
-#define SET_IRUN(n)			(((n)&0x1F)<<8)
-#define SET_IHOLD(n)		(((n)&0x1F)<<0)
-
-
-#define WRITE_ACCESS			0x80	// Write access for spi communication
-
-// Polarity for reference switch
-#define REF_SW_HIGH_ACTIV	0x00 	// non-inverted, high active: a high level on REFL stops the motor
-#define REF_SW_LOW_ACTIV	0x0C	// inverted, low active: a low level on REFL stops the motor
-
-// Motor direction
-#define NORMAL_MOTOR_DIRECTION	0x00	// Normal motor direction
-#define INVERSE_MOTOR_DIRECTION	0x10	// Inverse motor direction
-
-// Modes for RAMPMODE register
-#define POSITIONING_MODE	0x00		// using all A, D and V parameters)
-#define VELOCITY_MODE_POS	0x01		// positiv VMAX, using AMAX acceleration
-#define VELOCITY_MODE_NEG	0x02		// negativ VMAX, using AMAX acceleration
-#define HOLD_MODE			0x03		// velocity remains unchanged, unless stop event occurs
-
-#define VZERO				0x400		// flag in RAMP_STAT, 1: signals that the actual velocity is 0.
 
 #endif // ESTEE_TMC5130_H

--- a/Estee_TMC5130.h
+++ b/Estee_TMC5130.h
@@ -101,9 +101,10 @@ public:
 	uint32_t readRegister(uint8_t address) { return readRegister(address, nullptr); }
 	uint8_t  writeRegister(uint8_t address, uint32_t data);
 
+	void resetCommunication(); // Reset communication with TMC5130 : pause activity on the serial bus.
+
 	void setSlaveAddress(uint8_t slaveAddress);
 
-	//TODO handle communication reset ?
 	//TODO add optional internal checks (reg write counter, retry in case of bad CRC)
 
 

--- a/Estee_TMC5130.h
+++ b/Estee_TMC5130.h
@@ -140,7 +140,7 @@ public:
 
 	void resetCommunication(); // Reset communication with TMC5130 : pause activity on the serial bus.
 
-	void setSlaveAddress(uint8_t slaveAddress);
+	void setSlaveAddress(uint8_t slaveAddress, bool NAI=true); // Set the slave address register. Take into account the TMC5130 NAI input (default to high). Range : 0 - 253 if NAI is low, 1 - 254 if NAI is high.
 
 	//TODO add optional internal checks (reg write counter, retry in case of bad CRC)
 

--- a/Estee_TMC5130_SPI.cpp
+++ b/Estee_TMC5130_SPI.cpp
@@ -74,13 +74,13 @@ uint32_t Estee_TMC5130_SPI::readRegister(uint8_t address)
 	_beginTransaction();
 	_spi->transfer(address);
 	uint32_t value = 0;
-	value |= _spi->transfer(0x00) << 24;
-	value |= _spi->transfer(0x00) << 16;
-	value |= _spi->transfer(0x00) << 8;
-	value |= _spi->transfer(0x00);
+	value |= (uint32_t)_spi->transfer(0x00) << 24;
+	value |= (uint32_t)_spi->transfer(0x00) << 16;
+	value |= (uint32_t)_spi->transfer(0x00) << 8;
+	value |= (uint32_t)_spi->transfer(0x00);
 	_endTransaction();
 
-	_lastRegisterReadSuccess = true; // In SPI mode there is no way to know if the TMC5130 is plugged... 
+	_lastRegisterReadSuccess = true; // In SPI mode there is no way to know if the TMC5130 is plugged...
 
 	return value;
 }

--- a/Estee_TMC5130_SPI.cpp
+++ b/Estee_TMC5130_SPI.cpp
@@ -80,6 +80,8 @@ uint32_t Estee_TMC5130_SPI::readRegister(uint8_t address)
 	value |= _spi->transfer(0x00);
 	_endTransaction();
 
+	_lastRegisterReadSuccess = true; // In SPI mode there is no way to know if the TMC5130 is plugged... 
+
 	return value;
 }
 

--- a/Estee_TMC5130_SPI.cpp
+++ b/Estee_TMC5130_SPI.cpp
@@ -1,0 +1,119 @@
+/*
+MIT License
+
+Copyright (c) 2016 Mike Estee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "Estee_TMC5130.h"
+
+Estee_TMC5130_SPI::Estee_TMC5130_SPI( uint8_t chipSelectPin, uint32_t fclk, const SPISettings &spiSettings, SPIClass &spi )
+: Estee_TMC5130(fclk), _CS(chipSelectPin), _spiSettings(spiSettings), _spi(spi)
+{
+
+}
+
+#pragma mark -
+
+// calls to read/write registers must be bracketed by the begin/endTransaction calls
+
+void _chipSelect( uint8_t pin, bool select )
+{
+	digitalWrite(pin, select?LOW:HIGH);
+	if( select )
+		delayMicroseconds(100);   // per spec, settling time is 100us
+}
+
+void Estee_TMC5130_SPI::_beginTransaction()
+{
+	_spi.beginTransaction(_spiSettings);
+	_chipSelect(_CS, true);
+}
+
+void Estee_TMC5130_SPI::_endTransaction()
+{
+	_chipSelect(_CS, false);
+	_spi.endTransaction();
+}
+
+uint32_t Estee_TMC5130_SPI::readRegister(uint8_t address)
+{
+	// request the read for the address
+	_beginTransaction();
+	_spi.transfer(address);
+	_spi.transfer(0x00);
+	_spi.transfer(0x00);
+	_spi.transfer(0x00);
+	_spi.transfer(0x00);
+	_endTransaction();
+
+	// skip a beat
+	#define nop() asm volatile("nop")
+	nop();
+	nop();
+	nop();
+
+	// read it in the second cycle
+	_beginTransaction();
+	_spi.transfer(address);
+	uint32_t value = 0;
+	value |= _spi.transfer(0x00) << 24;
+	value |= _spi.transfer(0x00) << 16;
+	value |= _spi.transfer(0x00) << 8;
+	value |= _spi.transfer(0x00);
+	_endTransaction();
+
+	return value;
+}
+
+uint8_t Estee_TMC5130_SPI::writeRegister(uint8_t address, uint32_t data)
+{
+	// address register
+	_beginTransaction();
+	uint8_t status = _spi.transfer(address | WRITE_ACCESS);
+
+	// send new register value
+	_spi.transfer((data & 0xFF000000) >> 24);
+	_spi.transfer((data & 0xFF0000) >> 16);
+	_spi.transfer((data & 0xFF00) >> 8);
+	_spi.transfer(data & 0xFF);
+	_endTransaction();
+
+	return status;
+}
+
+
+uint8_t Estee_TMC5130_SPI::readStatus()
+{
+ 	// read general config
+ 	_beginTransaction();
+ 	uint8_t status = _spi.transfer(GCONF);
+ 	// send dummy data
+ 	_spi.transfer(0x00);
+ 	_spi.transfer(0x00);
+ 	_spi.transfer(0x00);
+ 	_spi.transfer(0x00);
+ 	_endTransaction();
+
+	return status;
+}
+
+
+#pragma mark -

--- a/Estee_TMC5130_SPI.cpp
+++ b/Estee_TMC5130_SPI.cpp
@@ -104,7 +104,7 @@ uint8_t Estee_TMC5130_SPI::readStatus()
 {
  	// read general config
  	_beginTransaction();
- 	uint8_t status = _spi.transfer(GCONF);
+ 	uint8_t status = _spi.transfer(TMC5130_Reg::GCONF);
  	// send dummy data
  	_spi.transfer(0x00);
  	_spi.transfer(0x00);

--- a/Estee_TMC5130_SPI.cpp
+++ b/Estee_TMC5130_SPI.cpp
@@ -27,7 +27,7 @@ SOFTWARE.
 Estee_TMC5130_SPI::Estee_TMC5130_SPI( uint8_t chipSelectPin, uint32_t fclk, const SPISettings &spiSettings, SPIClass &spi )
 : Estee_TMC5130(fclk), _CS(chipSelectPin), _spiSettings(spiSettings), _spi(&spi)
 {
-
+	pinMode(chipSelectPin, OUTPUT);
 }
 
 #pragma mark -

--- a/Estee_TMC5130_SPI.cpp
+++ b/Estee_TMC5130_SPI.cpp
@@ -25,7 +25,7 @@ SOFTWARE.
 #include "Estee_TMC5130.h"
 
 Estee_TMC5130_SPI::Estee_TMC5130_SPI( uint8_t chipSelectPin, uint32_t fclk, const SPISettings &spiSettings, SPIClass &spi )
-: Estee_TMC5130(fclk), _CS(chipSelectPin), _spiSettings(spiSettings), _spi(spi)
+: Estee_TMC5130(fclk), _CS(chipSelectPin), _spiSettings(spiSettings), _spi(&spi)
 {
 
 }
@@ -43,25 +43,25 @@ void _chipSelect( uint8_t pin, bool select )
 
 void Estee_TMC5130_SPI::_beginTransaction()
 {
-	_spi.beginTransaction(_spiSettings);
+	_spi->beginTransaction(_spiSettings);
 	_chipSelect(_CS, true);
 }
 
 void Estee_TMC5130_SPI::_endTransaction()
 {
 	_chipSelect(_CS, false);
-	_spi.endTransaction();
+	_spi->endTransaction();
 }
 
 uint32_t Estee_TMC5130_SPI::readRegister(uint8_t address)
 {
 	// request the read for the address
 	_beginTransaction();
-	_spi.transfer(address);
-	_spi.transfer(0x00);
-	_spi.transfer(0x00);
-	_spi.transfer(0x00);
-	_spi.transfer(0x00);
+	_spi->transfer(address);
+	_spi->transfer(0x00);
+	_spi->transfer(0x00);
+	_spi->transfer(0x00);
+	_spi->transfer(0x00);
 	_endTransaction();
 
 	// skip a beat
@@ -72,12 +72,12 @@ uint32_t Estee_TMC5130_SPI::readRegister(uint8_t address)
 
 	// read it in the second cycle
 	_beginTransaction();
-	_spi.transfer(address);
+	_spi->transfer(address);
 	uint32_t value = 0;
-	value |= _spi.transfer(0x00) << 24;
-	value |= _spi.transfer(0x00) << 16;
-	value |= _spi.transfer(0x00) << 8;
-	value |= _spi.transfer(0x00);
+	value |= _spi->transfer(0x00) << 24;
+	value |= _spi->transfer(0x00) << 16;
+	value |= _spi->transfer(0x00) << 8;
+	value |= _spi->transfer(0x00);
 	_endTransaction();
 
 	return value;
@@ -87,13 +87,13 @@ uint8_t Estee_TMC5130_SPI::writeRegister(uint8_t address, uint32_t data)
 {
 	// address register
 	_beginTransaction();
-	uint8_t status = _spi.transfer(address | WRITE_ACCESS);
+	uint8_t status = _spi->transfer(address | WRITE_ACCESS);
 
 	// send new register value
-	_spi.transfer((data & 0xFF000000) >> 24);
-	_spi.transfer((data & 0xFF0000) >> 16);
-	_spi.transfer((data & 0xFF00) >> 8);
-	_spi.transfer(data & 0xFF);
+	_spi->transfer((data & 0xFF000000) >> 24);
+	_spi->transfer((data & 0xFF0000) >> 16);
+	_spi->transfer((data & 0xFF00) >> 8);
+	_spi->transfer(data & 0xFF);
 	_endTransaction();
 
 	return status;
@@ -104,12 +104,12 @@ uint8_t Estee_TMC5130_SPI::readStatus()
 {
  	// read general config
  	_beginTransaction();
- 	uint8_t status = _spi.transfer(TMC5130_Reg::GCONF);
+ 	uint8_t status = _spi->transfer(TMC5130_Reg::GCONF);
  	// send dummy data
- 	_spi.transfer(0x00);
- 	_spi.transfer(0x00);
- 	_spi.transfer(0x00);
- 	_spi.transfer(0x00);
+ 	_spi->transfer(0x00);
+ 	_spi->transfer(0x00);
+ 	_spi->transfer(0x00);
+ 	_spi->transfer(0x00);
  	_endTransaction();
 
 	return status;

--- a/Estee_TMC5130_UART.cpp
+++ b/Estee_TMC5130_UART.cpp
@@ -88,6 +88,17 @@ uint8_t Estee_TMC5130_UART::writeRegister(uint8_t address, uint32_t data)
 	return 0;
 }
 
+void Estee_TMC5130_UART::resetCommunication()
+{
+	//FIXME should take into account the previous baud rate !
+	// For now let's wait 1ms. The spec asks for ~75 bit times so this should be OK for baud rates > 75kbps
+	delay(1);
+
+	//Flush input buffer.
+	while (_serial.available())
+		_serial.read();
+}
+
 void Estee_TMC5130_UART::setSlaveAddress(uint8_t slaveAddress)
 {
 	_slaveAddress = slaveAddress;

--- a/Estee_TMC5130_UART.cpp
+++ b/Estee_TMC5130_UART.cpp
@@ -284,7 +284,7 @@ void Estee_TMC5130_UART::_writeReg(uint8_t address, uint32_t data)
 	computeCrc(buffer, 8);
 
 #if 0
-	//Intentional disturbation to test the reliable mode : change the CRC
+	//Intentional interference to test the reliable mode : change the CRC
 	if (random(256) < 64)
 		buffer[7]++;
 #endif

--- a/Estee_TMC5130_UART.cpp
+++ b/Estee_TMC5130_UART.cpp
@@ -115,9 +115,15 @@ void Estee_TMC5130_UART::resetCommunication()
 		_serial.read();
 }
 
-void Estee_TMC5130_UART::setSlaveAddress(uint8_t slaveAddress)
+void Estee_TMC5130_UART::setSlaveAddress(uint8_t slaveAddress, bool NAI)
 {
-	_slaveAddress = slaveAddress;
+	TMC5130_Reg::SLAVECONF_Register slaveConf = { 0 };
+	slaveConf.senddelay = 2; // minimum if more than one slave is present.
+	slaveConf.slaveaddr = constrain(NAI ? slaveAddress-1 : slaveAddress, 0, 253); //NB : if NAI is high SLAVE_ADDR is incremented.
+
+	writeRegister(TMC5130_Reg::SLAVECONF, slaveConf.value);
+
+	_slaveAddress = NAI ? slaveConf.slaveaddr+1 : slaveConf.slaveaddr;
 }
 
 /* From Trinamic TMC5130A datasheet Rev. 1.14 / 2017-MAY-15 §5.2 */

--- a/Estee_TMC5130_UART.cpp
+++ b/Estee_TMC5130_UART.cpp
@@ -249,7 +249,7 @@ uint32_t Estee_TMC5130_UART::_readReg(uint8_t address, ReadStatus *status)
 
 	uint32_t data = 0;
 	for (int i = 0; i < 4; i++)
-		data += (inBuffer[3+i] << ((3-i)*8));
+		data += ((uint32_t)inBuffer[3+i] << ((3-i)*8));
 
 	#ifdef SERIAL_DEBUG
 	Serial.print("Read 0x");
@@ -279,7 +279,7 @@ void Estee_TMC5130_UART::_writeReg(uint8_t address, uint32_t data)
 	buffer[1] = _slaveAddress;
 	buffer[2] = address | WRITE_ACCESS;
 	for (int i = 0; i < 4; i++)
-		buffer[3+i] = (data & (0xFF << ((3-i)*8))) >> ((3-i)*8);
+		buffer[3+i] = (data & (0xFFul << ((3-i)*8))) >> ((3-i)*8);
 
 	computeCrc(buffer, 8);
 

--- a/Estee_TMC5130_UART.cpp
+++ b/Estee_TMC5130_UART.cpp
@@ -27,7 +27,7 @@ SOFTWARE.
 //#define SERIAL_DEBUG
 
 Estee_TMC5130_UART::Estee_TMC5130_UART(Stream& serial, uint8_t slaveAddress, uint32_t fclk)
-: Estee_TMC5130(fclk), _serial(serial), _slaveAddress(slaveAddress), _currentMode(STREAMING_MODE)
+: Estee_TMC5130(fclk), _serial(&serial), _slaveAddress(slaveAddress), _currentMode(STREAMING_MODE)
 {
 
 }
@@ -129,8 +129,8 @@ void Estee_TMC5130_UART::resetCommunication()
 #endif
 
 	//Flush input buffer.
-	while (_serial.available())
-		_serial.read();
+	while (_serial->available())
+		_serial->read();
 }
 
 void Estee_TMC5130_UART::setSlaveAddress(uint8_t slaveAddress, bool NAI)
@@ -187,12 +187,12 @@ uint32_t Estee_TMC5130_UART::_readReg(uint8_t address, ReadStatus *status)
 	computeCrc(outBuffer, 4);
 
 	beginTransmission();
-	_serial.write(outBuffer, 4);
+	_serial->write(outBuffer, 4);
 	endTransmission();
 
 	_readAttemptsCounter++;
 
-	if (_serial.readBytes(inBuffer, 8) != 8) //Stream.setTimeout has to be set to a decent value to avoid blocking
+	if (_serial->readBytes(inBuffer, 8) != 8) //Stream.setTimeout has to be set to a decent value to avoid blocking
 	{
 		if (status != nullptr)
 			*status = NO_REPLY;
@@ -266,7 +266,7 @@ void Estee_TMC5130_UART::_writeReg(uint8_t address, uint32_t data)
 #endif
 
 	beginTransmission();
-	_serial.write(buffer, 8);
+	_serial->write(buffer, 8);
 	endTransmission();
 }
 

--- a/Estee_TMC5130_UART.cpp
+++ b/Estee_TMC5130_UART.cpp
@@ -1,0 +1,107 @@
+/*
+MIT License
+
+Copyright (c) 2017 Tom Magnier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "Estee_TMC5130.h"
+
+Estee_TMC5130_UART::Estee_TMC5130_UART(Stream& serial, uint8_t slaveAddress, uint32_t fclk)
+: Estee_TMC5130(fclk), _serial(serial), _slaveAddress(slaveAddress)
+{
+
+}
+
+uint32_t Estee_TMC5130_UART::readRegister(uint8_t address)
+{
+	uint8_t outBuffer[4], inBuffer[8];
+
+	outBuffer[0] = SYNC_BYTE;
+	outBuffer[1] = _slaveAddress;
+	outBuffer[2] = address;
+
+	computeCrc(outBuffer, 4);
+
+	beginTransmission();
+	_serial.write(outBuffer, 4);
+	endTransmission();
+
+	if (_serial.readBytes(inBuffer, 8) != 8) //Stream.setTimeout has to be set to a decent value to avoid blocking
+		return 0xFFFFFFFF; //TODO return error code
+
+	uint8_t receivedCrc = inBuffer[7];
+	computeCrc(inBuffer, 8);
+
+	if (receivedCrc != inBuffer[7])
+		return 0xFFFFFFFF; //TODO return error code
+
+	uint32_t data = 0;
+	for (int i = 0; i < 4; i++)
+		data += (inBuffer[3+i] << ((3-i)*8));
+
+	return data;
+}
+
+uint8_t Estee_TMC5130_UART::writeRegister(uint8_t address, uint32_t data)
+{
+	uint8_t buffer[8];
+	buffer[0] = SYNC_BYTE;
+	buffer[1] = _slaveAddress;
+	buffer[2] = address | WRITE_ACCESS;
+	for (int i = 0; i < 4; i++)
+		buffer[3+i] = (data & (0xFF << ((3-i)*8))) >> ((3-i)*8);
+
+	computeCrc(buffer, 8);
+
+	beginTransmission();
+	_serial.write(buffer, 8);
+	endTransmission();
+
+	return 0;
+}
+
+void Estee_TMC5130_UART::setSlaveAddress(uint8_t slaveAddress)
+{
+	_slaveAddress = slaveAddress;
+}
+
+/* From Trinamic TMC5130A datasheet Rev. 1.14 / 2017-MAY-15 §5.2 */
+void Estee_TMC5130_UART::computeCrc(uint8_t *datagram, uint8_t datagramLength)
+{
+	int i,j;
+	uint8_t* crc = datagram + (datagramLength-1); // CRC located in last byte of message
+	uint8_t currentByte;
+
+	*crc = 0;
+	for (i = 0; i < (datagramLength-1); i++)
+	{
+		currentByte = datagram[i];
+		for (j = 0; j < 8; j++)
+		{
+			if ((*crc >> 7) ^ (currentByte & 0x01))
+				*crc = (*crc << 1) ^ 0x07;
+			else
+				*crc = (*crc << 1);
+
+			currentByte = currentByte >> 1;
+		} // for CRC bit
+	} // for message byte
+}

--- a/Estee_TMC5130_UART.cpp
+++ b/Estee_TMC5130_UART.cpp
@@ -50,6 +50,13 @@ uint32_t Estee_TMC5130_UART::readRegister(uint8_t address, ReadStatus *status)
 	{
 		if (status != nullptr)
 			*status = NO_REPLY;
+
+#ifdef SERIAL_DEBUG
+		Serial.print("Read 0x");
+		Serial.print(address, HEX);
+		Serial.println(": No reply.");
+#endif
+
 		return 0xFFFFFFFF;
 	}
 
@@ -60,6 +67,13 @@ uint32_t Estee_TMC5130_UART::readRegister(uint8_t address, ReadStatus *status)
 	{
 		if (status != nullptr)
 			*status = BAD_CRC;
+
+#ifdef SERIAL_DEBUG
+		Serial.print("Read 0x");
+		Serial.print(address, HEX);
+		Serial.println(": Bad CRC.");
+#endif
+
 		return 0xFFFFFFFF;
 	}
 
@@ -118,7 +132,7 @@ void Estee_TMC5130_UART::resetCommunication()
 void Estee_TMC5130_UART::setSlaveAddress(uint8_t slaveAddress, bool NAI)
 {
 	TMC5130_Reg::SLAVECONF_Register slaveConf = { 0 };
-	slaveConf.senddelay = 2; // minimum if more than one slave is present.
+	slaveConf.senddelay = 4; // minimum if more than one slave is present.
 	slaveConf.slaveaddr = constrain(NAI ? slaveAddress-1 : slaveAddress, 0, 253); //NB : if NAI is high SLAVE_ADDR is incremented.
 
 	writeRegister(TMC5130_Reg::SLAVECONF, slaveConf.value);

--- a/Estee_TMC5130_UART.cpp
+++ b/Estee_TMC5130_UART.cpp
@@ -24,6 +24,8 @@ SOFTWARE.
 
 #include "Estee_TMC5130.h"
 
+//#define SERIAL_DEBUG
+
 Estee_TMC5130_UART::Estee_TMC5130_UART(Stream& serial, uint8_t slaveAddress, uint32_t fclk)
 : Estee_TMC5130(fclk), _serial(serial), _slaveAddress(slaveAddress)
 {
@@ -65,6 +67,13 @@ uint32_t Estee_TMC5130_UART::readRegister(uint8_t address, ReadStatus *status)
 	for (int i = 0; i < 4; i++)
 		data += (inBuffer[3+i] << ((3-i)*8));
 
+#ifdef SERIAL_DEBUG
+	Serial.print("Read 0x");
+	Serial.print(address, HEX);
+	Serial.print(": 0x");
+	Serial.println(data, HEX);
+#endif
+
 	if (status != nullptr)
 		*status = SUCCESS;
 	return data;
@@ -72,6 +81,13 @@ uint32_t Estee_TMC5130_UART::readRegister(uint8_t address, ReadStatus *status)
 
 uint8_t Estee_TMC5130_UART::writeRegister(uint8_t address, uint32_t data)
 {
+#ifdef SERIAL_DEBUG
+	Serial.print("Writing 0x");
+	Serial.print(address, HEX);
+	Serial.print(": 0x");
+	Serial.println(data, HEX);
+#endif
+
 	uint8_t buffer[8];
 	buffer[0] = SYNC_BYTE;
 	buffer[1] = _slaveAddress;

--- a/Estee_TMC5130_registers.h
+++ b/Estee_TMC5130_registers.h
@@ -201,8 +201,7 @@ namespace TMC5130_Reg {
     BitField< 3> ignore_AB; // Ignore A and B polarity for N channel event
     BitField< 4> clr_cont; // Always latch or latch and clear X_ENC upon an N event
     BitField< 5> clr_once; // Latch or latch and clear X_ENC on the next N event following the write access
-    BitField< 6> pos_edge; // N channel event sensitivity
-    BitField< 7> neg_edge; // N channel event sensitivity
+    BitField< 6, 2> sensitivity; // N channel event sensitivity
     BitField< 8> clr_enc_x; // Clear encoder counter X_ENC upon N-event
     BitField< 9> latch_x_act; // Also latch XACTUAL position together with X_ENC.
     BitField<10> enc_sel_decimal; // Encoder prescaler divisor binary mode (0) / decimal mode (1)
@@ -288,6 +287,13 @@ namespace TMC5130_Reg {
     FREEWHEEL_ENABLED  = 0x01, // Freewheeling
     FREEWHEEL_SHORT_LS = 0x02, // Coil shorted using LS drivers
     FREEWHEEL_SHORT_HS = 0x03  // Coil shorted using HS drivers
+  };
+
+  enum ENCMODE_sensitivity_Values {
+    ENCODER_N_NO_EDGE       = 0x00, // N channel active while the N event is valid
+    ENCODER_N_RISING_EDGE   = 0x01, // N channel active when the N event is activated
+    ENCODER_N_FALLING_EDGE  = 0x02, // N channel active when the N event is de-activated
+    ENCODER_N_BOTH_EDGES    = 0x03  // N channel active on N event activation and de-activation
   };
 }
 

--- a/Estee_TMC5130_registers.h
+++ b/Estee_TMC5130_registers.h
@@ -1,0 +1,294 @@
+/*
+MIT License
+
+Copyright (c) 2017 Tom Magnier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef ESTEE_TMC5130_REGISTERS_H
+#define ESTEE_TMC5130_REGISTERS_H
+
+#include <util/Bitfield.h>
+
+namespace TMC5130_Reg {
+
+  /* Register addresses */
+  enum {
+    /* General configuration registers */
+    GCONF             = 0x00, // Global configuration flags
+    GSTAT             = 0x01, // Global status flags
+    IFCNT             = 0x02, // UART transmission counter
+    SLAVECONF         = 0x03, // UART slave configuration
+    IO_INPUT_OUTPUT   = 0x04, // Read input / write output pins
+    X_COMPARE         = 0x05, // Position comparison register
+
+    /* Velocity dependent driver feature control registers */
+    IHOLD_IRUN        = 0x10, // Driver current control
+    TPOWERDOWN        = 0x11, // Delay before power down
+    TSTEP             = 0x12, // Actual time between microsteps
+    TPWMTHRS          = 0x13, // Upper velocity for stealthChop voltage PWM mode
+    TCOOLTHRS         = 0x14, // Lower threshold velocity for switching on smart energy coolStep and stallGuard feature
+    THIGH             = 0x15, // Velocity threshold for switching into a different chopper mode and fullstepping
+
+    /* Ramp generator motion control registers */
+    RAMPMODE          = 0x20, // Driving mode (Velocity, Positioning, Hold)
+    XACTUAL           = 0x21, // Actual motor position
+    VACTUAL           = 0x22, // Actual  motor  velocity  from  ramp  generator
+    VSTART            = 0x23, // Motor start velocity
+    A_1               = 0x24, // First acceleration between VSTART and V1
+    V_1               = 0x25, // First acceleration/deceleration phase target velocity
+    AMAX              = 0x26, // Second acceleration between V1 and VMAX
+    VMAX              = 0x27, // Target velocity in velocity mode
+    DMAX              = 0x28, // Deceleration between VMAX and V1
+    D_1               = 0x2A, // Deceleration between V1 and VSTOP
+      //Attention:  Do  not  set  0  in  positioning  mode, even if V1=0!
+    VSTOP             = 0x2B, // Motor stop velocity
+      //Attention: Set VSTOP > VSTART!
+      //Attention:  Do  not  set  0  in  positioning  mode, minimum 10 recommend!
+    TZEROWAIT         = 0x2C, // Waiting time after ramping down to zero velocity before next movement or direction inversion can start.
+    XTARGET           = 0x2D, // Target position for ramp mode
+
+    /* Ramp generator driver feature control registers */
+    VDCMIN            = 0x33, // Velocity threshold for enabling automatic commutation dcStep
+    SW_MODE           = 0x34, // Switch mode configuration
+    RAMP_STAT         = 0x35, // Ramp status and switch event status
+    XLATCH            = 0x36, // Ramp generator latch position upon programmable switch event
+
+    /* Encoder registers */
+    ENCMODE           = 0x38, // Encoder configuration and use of N channel
+    X_ENC             = 0x39, // Actual encoder position
+    ENC_CONST         = 0x3A, // Accumulation constant
+    ENC_STATUS        = 0x3B, // Encoder N event detected
+    ENC_LATCH         = 0x3C, // Encoder position latched on N event
+
+    /* Motor driver registers */
+    MSLUT_0_7         = 0x60, // Microstep table entries. Add 0...7 for the next registers
+    MSLUTSEL          = 0x68, // Look up table segmentation definition
+    MSLUTSTART        = 0x69, // Absolute current at microstep table entries 0 and 256
+    MSCNT             = 0x6A, // Actual position in the microstep table
+    MSCURACT          = 0x6B, // Actual microstep current
+    CHOPCONF          = 0x6C, // Chopper and driver configuration
+    COOLCONF          = 0x6D, // coolStep smart current control register and stallGuard2 configuration
+    DCCTRL            = 0x6E, // dcStep automatic commutation configuration register
+    DRV_STATUS        = 0x6F, // stallGuard2 value and driver error flags
+    PWMCONF           = 0x70, // stealthChop voltage PWM mode chopper configuration
+    PWM_SCALE         = 0x71, // Actual PWM amplitude scaler
+    ENCM_CTRL         = 0x72, // Not for normal use.
+    LOST_STEPS        = 0x73 // Number of input steps skipped due to dcStep. only with SD_MODE = 1
+  };
+
+  /* Register bit fields */
+
+  /* General configuration register */
+  union GCONF_Register {
+    uint32_t value;
+    BitField< 0> I_scale_analog; // Use voltage supplied to AIN as current reference
+    BitField< 1> internal_Rsense; // Use internal sense resistors
+    BitField< 2> en_pwm_mode; // Enable stealthChop voltage PWM mode
+    BitField< 3> enc_commutation; // Special mode - do not use, leave 0
+    BitField< 4> shaft; // Normal / inverse motor direction
+    BitField< 5> diag0_error; // Enable DIAG0 active on driver errors: Over temperature (ot), short to GND (s2g), undervoltage chargepump (uv_cp)
+    BitField< 6> diag0_otpw; // Enable DIAG0 active on driver over temperature prewarning (otpw)
+    BitField< 7> diag0_stall_step; // SD_MODE=1: enable DIAG0 active on motor stall. SD_MODE=0: enable DIAG0 as STEP output
+    BitField< 8> diag1_stall_dir; // SD_MODE=1: enable DIAG1 active on motor stall. SD_MODE=0: enable DIAG1 as DIR output
+    BitField< 9> diag1_index; // Enable DIAG1 active on index position
+    BitField<10> diag1_onstate; // Enable DIAG1 active when chopper is on
+    BitField<11> diag1_steps_skipped; // Enable output toggle when steps are skipped in dcStep mode
+    BitField<12> diag0_int_pushpull; // Enable SWN_DIAG0 push pull output
+    BitField<13> diag1_poscomp_pushpull; // Enable SWP_DIAG1 push pull output
+    BitField<14> small_hysteresis; // Set small hysteresis for step frequency comparison
+    BitField<15> stop_enable; // Enable emergency stop: ENCA_DCIN stops the sequencer when tied high
+    BitField<16> direct_mode; // Enable direct motor coil current and polarity control
+    BitField<17> test_mode; // Not for normal use
+  };
+
+  /* Global status flags */
+  union GSTAT_Register {
+    uint32_t value;
+    BitField<0> reset; // Indicates that the IC has been reset since the last read access to GSTAT
+    BitField<1> drv_err; // Indicates that the driver has been shut down due to overtemperature or short circuit detection since the last read access
+    BitField<2> uv_cp; // Indicates an undervoltage on the charge pump. The driver is disabled in this case.
+  };
+
+  /* UART slave configuration */
+  union SLAVECONF_Register {
+    uint32_t value;
+    BitField<0, 8> slaveaddr; // Address of unit for the UART interface. The address becomes incremented by one when the external address pin NAI is active.
+    BitField<8, 2> senddelay; // Number of bit times before replying to a register read in UART mode. Set > 1 with multiple slaves.
+  };
+
+  /* Read input pins */
+  union IOIN_Register {
+    uint32_t value;
+    BitField<0> refl_step;
+    BitField<1> refr_dir;
+    BitField<2> encb_dcen_cfg4;
+    BitField<3> enca_dcin_cfg5;
+    BitField<4> drv_enn_cfg6;
+    BitField<5> enc_n_dco;
+    BitField<6> sd_mode; // 1=External step and dir source
+    BitField<7> swcomp_in;
+    BitField<24, 8> version;
+  };
+
+  /* Driver current control */
+  union IHOLD_IRUN_Register {
+    uint32_t value;
+    BitField< 0, 5> ihold; // Standstill current (0=1/32...31=32/32)
+    BitField< 8, 5> irun; // Motor run current (0=1/32...31=32/32). Should be between 16 and 31 for best performance.
+    BitField<16, 4> iholddelay; // Controls the number of clock cycles for motor power down when entering standstill
+  };
+
+  /* Switch mode configuration */
+  union SW_MODE_Register {
+    uint32_t value;
+    BitField< 0> stop_l_enable; // Enable automatic motor stop during active left reference switch input
+    BitField< 1> stop_r_enable; // Enable automatic motor stop during active right reference switch input
+    BitField< 2> pol_stop_l; // Sets the active polarity of the left reference switch input (1=inverted, low active, a low level on REFL stops the motor)
+    BitField< 3> pol_stop_r; // Sets the active polarity of the right reference switch input (1=inverted, low active, a low level on REFR stops the motor
+    BitField< 4> swap_lr; // Swap the left and the right reference switch inputs
+    BitField< 5> latch_l_active; // Activate latching of the position to XLATCH upon an active going edge on REFL
+    BitField< 6> latch_l_inactive; // Activate latching of the position to XLATCH upon an inactive going edge on REFL
+    BitField< 7> latch_r_active; // Activate latching of the position to XLATCH upon an active going edge on REFR
+    BitField< 8> latch_r_inactive; // Activate latching of the position to XLATCH upon an inactive going edge on REFR
+    BitField< 9> en_latch_encoder; // Latch encoder position to ENC_LATCH upon reference switch event
+    BitField<10> sg_stop; // Enable stop by stallGuard2 (also available in dcStep mode). Disable to release motor after stop event.
+    BitField<11> en_softstop; // Enable soft stop upon a stop event (uses the deceleration ramp settings)
+  };
+
+  /* Ramp status and switch event status */
+  union RAMP_STAT_Register {
+    uint32_t value;
+    BitField< 0> status_stop_l; // Reference switch left status (1=active)
+    BitField< 1> status_stop_r; // Reference switch right status (1=active)
+    BitField< 2> status_latch_l; // Latch left ready (enable position latching using SWITCH_MODE settings latch_l_active or latch_l_inactive)
+    BitField< 3> status_latch_r; // Latch right ready (enable position latching using SWITCH_MODE settings latch_r_active or latch_r_inactive)
+    BitField< 4> event_stop_l; // Signals an active stop left condition due to stop switch.
+    BitField< 5> event_stop_r; // Signals an active stop right condition due to stop switch.
+    BitField< 6> event_stop_sg; // Signals an active StallGuard2 stop event.
+    BitField< 7> event_pos_reached; // Signals that the target position has been reached (position_reached becoming active).
+    BitField< 8> velocity_reached; // Signals that the target velocity is reached.
+    BitField< 9> position_reached; // Signals that the target position is reached.
+    BitField<10> vzero; // Signals that the actual velocity is 0.
+    BitField<11> t_zerowait_active; // Signals that TZEROWAIT is active after a motor stop. During this time, the motor is in standstill.
+    BitField<12> second_move; // Signals that the automatic ramp required moving back in the opposite direction
+    BitField<13> status_sg; // Signals an active stallGuard2 input from the coolStep driver or from the dcStep unit, if enabled.
+  };
+
+  /* Encoder configuration and use of N channel */
+  union ENCMODE_Register {
+    uint32_t value;
+    BitField< 0> pol_A; // Required A polarity for an N channel event (0=neg., 1=pos.)
+    BitField< 1> pol_B; // Required B polarity for an N channel event (0=neg., 1=pos.)
+    BitField< 2> pol_N; // Defines active polarity of N (0=low active, 1=high active)
+    BitField< 3> ignore_AB; // Ignore A and B polarity for N channel event
+    BitField< 4> clr_cont; // Always latch or latch and clear X_ENC upon an N event
+    BitField< 5> clr_once; // Latch or latch and clear X_ENC on the next N event following the write access
+    BitField< 6> pos_edge; // N channel event sensitivity
+    BitField< 7> neg_edge; // N channel event sensitivity
+    BitField< 8> clr_enc_x; // Clear encoder counter X_ENC upon N-event
+    BitField< 9> latch_x_act; // Also latch XACTUAL position together with X_ENC.
+    BitField<10> enc_sel_decimal; // Encoder prescaler divisor binary mode (0) / decimal mode (1)
+  };
+
+  /* Chopper and driver configuration */
+  union CHOPCONF_Register {
+    uint32_t value;
+    BitField< 0, 4> toff; // Off time setting controls duration of slow decay phase. 0 : Driver disabled.
+    BitField< 4, 3> hstrt_tfd; // chm=0: hysteresis start value HSTRT, chm=1: fast decay time setting bits 0:2
+    BitField< 7, 4> hend_offset; // chm=0: hysteresis low value HEND, chm=1: sine wave offset
+    BitField<11>    tfd_3; // chm=1: fast decay time setting bit 3
+    BitField<12>    disfdcc; // chm=1: disable current comparator usage for termi- nation of the fast decay cycle
+    BitField<13>    rndtf; // enable random modulation of chopper TOFF time
+    BitField<14>    chm; // Chopper mode (0=standard - spreadCycle ; 1=constant off time with fast decay time)
+    BitField<15, 2> tbl; // Comparator blank time select.
+    BitField<17>    vsense; // Select resistor voltage sensitivity (0=Low sensitivity ; 1=High sensitivity)
+    BitField<18>    vhighfs; // Enable switching to fullstep when VHIGH is exceeded.
+    BitField<19>    vhighchm; // Enable switching to chm=1 and fd=0 when VHIGH is exceeded
+    BitField<20, 4> sync; // chopSync - synchronization of the chopper for both phases of the stepper motor
+    BitField<24, 4> mres; // Set microstep resolution
+    BitField<28>    intpol; // Enable interpolation to 256 microsteps with an external motion controller
+    BitField<29>    dedge; // Enable double edge step pulses
+    BitField<30>    diss2g; // Disable short to GND protection
+  };
+
+  /* coolStep smart current control and stallGuard2 configuration */
+  union COOLCONF_Register {
+    uint32_t value;
+    BitField< 0, 4> semin; // Minimum stallGuard2 value for smart current control and smart current enable
+    BitField< 5, 2> seup; // Current increment step width
+    BitField< 8, 4> semax; // stallGuard2 hysteresis value for smart current control
+    BitField<13, 2> sedn; // Current decrement step speed
+    BitField<15>    seimin; // Minimum current for smart current control
+    BitField<16, 7> sgt; // stallGuard2 threshold value
+    BitField<24>    sfilt; // Enable stallGuard2 filter
+  };
+
+  /* dcStep automatic commutation configuration register */
+  union DCCTRL_Register {
+    uint32_t value;
+    BitField< 0, 10> dc_time; // Upper PWM on time limit for commutation
+    BitField<16,  8> dc_sg; // Max. PWM on time for step loss detection using dcStep stallGuard2 in dcStep mode.
+  };
+
+  /* stallGuard2 value and driver error flags */
+  union DRV_STATUS_Register {
+    uint32_t value;
+    BitField< 0, 9> sg_result; // stallGuard2 result or motor temperature estimation in stand still
+    BitField<15>    fsactive; // Full step active indicator
+    BitField<16, 5> cs_actual; // Actual motor current / smart energy current
+    BitField<24>    stallguard; // stallGuard2 status
+    BitField<25>    ot; // overtemperature flag
+    BitField<26>    otpw; // overtemperature pre- warning flag
+    BitField<27>    s2ga; // short to ground indicator phase A
+    BitField<28>    s2gb; // short to ground indicator phase B
+    BitField<29>    ola; // open load indicator phase A
+    BitField<30>    olb; // open load indicator phase B
+    BitField<31>    stst; // standstill indicator
+  };
+
+  /* stealthChop voltage PWM mode chopper configuration */
+  union PWMCONF_Register {
+    uint32_t value;
+    BitField< 0, 8> pwm_ampl; // User defined PWM amplitude (offset)
+    BitField< 8, 8> pwm_grad; // User defined PWM amplitude (gradient) or regulation loop gradient
+    BitField<16, 2> pwm_freq; // PWM frequency selection
+    BitField<18>    pwm_autoscale; // Enable PWM automatic amplitude scaling
+    BitField<19>    pwm_symmetric; // Force symmetric PWM
+    BitField<20, 2> freewheel; // Stand still option when motor current setting is zero (I_HOLD=0).
+  };
+
+  /* Register field values */
+  enum RAMPMODE_Values {
+    POSITIONING_MODE  = 0x00,	// using all A, D and V parameters
+    VELOCITY_MODE_POS = 0x01,	// positive VMAX, using AMAX acceleration
+    VELOCITY_MODE_NEG = 0x02,	// negative VMAX, using AMAX acceleration
+    HOLD_MODE         = 0x03	// velocity remains unchanged, unless stop event occurs
+  };
+
+  enum PWMCONF_freewheel_Values {
+    FREEWHEEL_NORMAL   = 0x00, // Normal operation
+    FREEWHEEL_ENABLED  = 0x01, // Freewheeling
+    FREEWHEEL_SHORT_LS = 0x02, // Coil shorted using LS drivers
+    FREEWHEEL_SHORT_HS = 0x03  // Coil shorted using HS drivers
+  };
+}
+
+#endif // ESTEE_TMC5130_REGISTERS_H

--- a/Estee_TMC5130_registers.h
+++ b/Estee_TMC5130_registers.h
@@ -131,7 +131,7 @@ namespace TMC5130_Reg {
   union SLAVECONF_Register {
     uint32_t value;
     BitField<0, 8> slaveaddr; // Address of unit for the UART interface. The address becomes incremented by one when the external address pin NAI is active.
-    BitField<8, 2> senddelay; // Number of bit times before replying to a register read in UART mode. Set > 1 with multiple slaves.
+    BitField<8, 4> senddelay; // Number of bit times before replying to a register read in UART mode. Set > 1 with multiple slaves.
   };
 
   /* Read input pins */

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # tmc5130
 Trinamic TMC5130 Arduino Library
 
-This library is intended as a basic driver library for controlling Trinamic TMC5130A chips in SPI mode.
+This library is intended as a basic driver library for controlling Trinamic TMC5130A chips in SPI or UART mode.

--- a/examples/back_and_forth_spi/back_and_forth_spi.ino
+++ b/examples/back_and_forth_spi/back_and_forth_spi.ino
@@ -6,7 +6,7 @@ uint8_t TMC_CS = PIN_A5;  // Chip select, Active LOW. next to SCK/MOSI/MISO on t
 uint8_t TMC_EN = 10;      // Drive enable pin. Active LOW. Optional, you can also just tie to ground
 uint8_t BLE_CS = 8;       // Hidden pin #8 which controls the SS line for the Bluetooth module SPI comms
 
-Estee_TMC5130 tmc = Estee_TMC5130(TMC_CS);
+Estee_TMC5130_SPI tmc = Estee_TMC5130_SPI(TMC_CS);
 
 void setup()
 {
@@ -19,7 +19,7 @@ void setup()
   digitalWrite(TMC_EN, HIGH); // disabled for start
   pinMode(TMC_CS, OUTPUT);
   digitalWrite(TMC_EN, HIGH);
-  
+
   // disable BLE talking on SPI bus
 #if defined(ARDUINO_SAMD_ZERO)
   pinMode(BLE_CS, OUTPUT);
@@ -63,7 +63,7 @@ bool dir = false;
 void loop()
 {
   uint32_t now = millis();
-  
+
   // every n seconds or so...
   if ( now - t_dirchange > 3000 )
   {

--- a/examples/back_and_forth_spi/back_and_forth_spi.ino
+++ b/examples/back_and_forth_spi/back_and_forth_spi.ino
@@ -12,6 +12,7 @@ void setup()
 {
   // init serial coms
   Serial.begin(9600);
+
   SPI.begin();
 
   // chip select & drive enable
@@ -37,17 +38,10 @@ void setup()
 //  delay(5000);
 
   // ramp definition
-  uint32_t onerev = 200*256;
-  tmc.writeRegister(TMC5130_Reg::VSTART, 0x0);
-  tmc.writeRegister(TMC5130_Reg::A_1, 1000);
-  tmc.writeRegister(TMC5130_Reg::V_1, 50000);
-  tmc.writeRegister(TMC5130_Reg::AMAX, 500);
-  tmc.writeRegister(TMC5130_Reg::VMAX, 200000);
-  tmc.writeRegister(TMC5130_Reg::DMAX, 700);
-  tmc.writeRegister(TMC5130_Reg::D_1, 1400);
-  tmc.writeRegister(TMC5130_Reg::VSTOP, 10);
-  tmc.writeRegister(TMC5130_Reg::TZEROWAIT, 0);
-  tmc.writeRegister(TMC5130_Reg::RAMPMODE, TMC5130_Reg::POSITIONING_MODE);
+  tmc.setRampMode(Estee_TMC5130::POSITIONING_MODE);
+  tmc.setMaxSpeed(200);
+  tmc.setRampSpeeds(0, 0.1, 100); //Start, stop, threshold speeds
+  tmc.setAccelerations(250, 350, 500, 700); //AMAX, DMAX, A1, D1
 
   Serial.println("starting up");
 
@@ -71,7 +65,7 @@ void loop()
 
     // reverse direction
     dir = !dir;
-    tmc.writeRegister(TMC5130_Reg::XTARGET, dir?(200*256):0);  // 1 full rotatation = 200s/rev * 256microsteps
+    tmc.setTargetPosition(dir ? 200 : 0);  // 1 full rotation = 200s/rev
   }
 
   // print out current position
@@ -80,9 +74,8 @@ void loop()
     t_echo = now;
 
     // get the current target position
-    int32_t xactual = 0, vactual = 0;
-    xactual = tmc.readRegister(TMC5130_Reg::XACTUAL);
-    vactual = tmc.readRegister(TMC5130_Reg::VACTUAL);
+    int32_t xactual = tmc.getCurrentPosition();
+    float vactual = tmc.getCurrentSpeed();
 
     Serial.print("xpos,v:");
     Serial.print(xactual);

--- a/examples/back_and_forth_spi/back_and_forth_spi.ino
+++ b/examples/back_and_forth_spi/back_and_forth_spi.ino
@@ -27,7 +27,7 @@ void setup()
 #endif
 
   // This sets the motor currents for HOLD & RUN, as well as the natural motor direction for positive moves
-  tmc.begin(0x4, 0x4, NORMAL_MOTOR_DIRECTION);
+  tmc.begin(4, 4, Estee_TMC5130::NORMAL_MOTOR_DIRECTION);
 
   // drive *MUST* be disabled when testing frequency scaling
 //  digitalWrite(TMC_EN, HIGH);
@@ -38,16 +38,16 @@ void setup()
 
   // ramp definition
   uint32_t onerev = 200*256;
-  tmc.writeRegister(VSTART, 0x0);
-  tmc.writeRegister(A_1, 1000);
-  tmc.writeRegister(V_1, 50000);
-  tmc.writeRegister(AMAX, 500);
-  tmc.writeRegister(VMAX, 200000);
-  tmc.writeRegister(DMAX, 700);
-  tmc.writeRegister(D_1, 1400);
-  tmc.writeRegister(VSTOP, 10);
-  tmc.writeRegister(TZEROWAIT, 0);
-  tmc.writeRegister(RAMPMODE, 0);
+  tmc.writeRegister(TMC5130_Reg::VSTART, 0x0);
+  tmc.writeRegister(TMC5130_Reg::A_1, 1000);
+  tmc.writeRegister(TMC5130_Reg::V_1, 50000);
+  tmc.writeRegister(TMC5130_Reg::AMAX, 500);
+  tmc.writeRegister(TMC5130_Reg::VMAX, 200000);
+  tmc.writeRegister(TMC5130_Reg::DMAX, 700);
+  tmc.writeRegister(TMC5130_Reg::D_1, 1400);
+  tmc.writeRegister(TMC5130_Reg::VSTOP, 10);
+  tmc.writeRegister(TMC5130_Reg::TZEROWAIT, 0);
+  tmc.writeRegister(TMC5130_Reg::RAMPMODE, TMC5130_Reg::POSITIONING_MODE);
 
   Serial.println("starting up");
 
@@ -71,7 +71,7 @@ void loop()
 
     // reverse direction
     dir = !dir;
-    tmc.writeRegister(XTARGET, dir?(200*256):0);  // 1 full rotatation = 200s/rev * 256microsteps
+    tmc.writeRegister(TMC5130_Reg::XTARGET, dir?(200*256):0);  // 1 full rotatation = 200s/rev * 256microsteps
   }
 
   // print out current position
@@ -81,8 +81,8 @@ void loop()
 
     // get the current target position
     int32_t xactual = 0, vactual = 0;
-    xactual = tmc.readRegister(XACTUAL);
-    vactual = tmc.readRegister(VACTUAL);
+    xactual = tmc.readRegister(TMC5130_Reg::XACTUAL);
+    vactual = tmc.readRegister(TMC5130_Reg::VACTUAL);
 
     Serial.print("xpos,v:");
     Serial.print(xactual);

--- a/examples/back_and_forth_uart/back_and_forth_uart.ino
+++ b/examples/back_and_forth_uart/back_and_forth_uart.ino
@@ -1,0 +1,143 @@
+/* TMC5130 UART example
+
+This code demonstrates the usage of a Trinamic TMC5130 stepper driver using its
+single-wire interface.
+
+Hardware setup :
+A RS485 transceiver must be connected to the Serial1 pins with the TX Enable pin
+accessible to the uC
+
+Tie the A output to the TMC5130 I/O voltage with a 1k resistor (see TMC5130 datasheet
+Fig 5.2)
+
+The TMC5130 Enable line must be connected to GND to enable the driver.
+
+                                                3.3/5V
+                                                  +     +-----------------+
+                                            +-----+---+-+ VCC_IO          |
+                                            |         | |                 |
+                                           +++        | |                 |
++-----------+        +--------------+      | | 1k     +-+ SWSEL           |
+|           |        |              |      +++          |                 |
+|      RX 0 +--------+ RO           |       |           |                 |
+|           |        |            A +-------+-----------+ SWP         NAI ++ open
+|           |    +---+ /RE          |                   |                 |
+|   TX EN 5 +----+   |            B +-------------------+ SWN             |
+|           |    +---+ DE           |                   |                 |
+|           |        |          GND +----+         +----+ DRV_ENN         |
+|      TX 1 +--------+ DI           |    |         |    |                 |
+|           |        |              |    +---------+----+ GND             |
++-----------+        +--------------+                   +-----------------+
+ Feather M0               MAX3485                              TMC5130
+                       or equivalent
+
+
+Tested on Adafruit Feather M0.
+
+Copyright (c) 2017 Tom Magnier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <Arduino.h>
+#include <Estee_TMC5130.h>
+
+const uint8_t UART_TX_EN = 5;   // Differential transceiver TX enable pin
+
+Estee_TMC5130_UART_Transceiver tmc = Estee_TMC5130_UART_Transceiver(UART_TX_EN, Serial1, 1); //Use Serial1 (hardware UART on Feather M0) ; address 1 (NAI input has a pull up resistor)
+
+void setup()
+{
+  // init serial coms
+  Serial.begin(9600);
+  while(!Serial);
+
+  // Init TMC serial bus @ 250kbps
+  Serial1.begin(250000);
+  Serial1.setTimeout(5); // TMC5130 should answer back immediately when reading a register.
+
+  // status LED
+  pinMode(LED_BUILTIN, OUTPUT);
+
+  // This sets the motor currents for HOLD & RUN, as well as the natural motor direction for positive moves
+  tmc.begin(0x4, 0x4, NORMAL_MOTOR_DIRECTION);
+
+  // drive *MUST* be disabled when testing frequency scaling
+  //  digitalWrite(TMC_EN, HIGH);
+  //  float freq = tmc.updateFrequencyScaling();
+  //  Serial.print("frequency scaling: ");
+  //  Serial.println(freq);
+  //  delay(5000);
+
+  // ramp definition
+  uint32_t onerev = 200*256;
+  tmc.writeRegister(VSTART, 0x0);
+  tmc.writeRegister(A_1, 1000);
+  tmc.writeRegister(V_1, 50000);
+  tmc.writeRegister(AMAX, 500);
+  tmc.writeRegister(VMAX, 200000);
+  tmc.writeRegister(DMAX, 700);
+  tmc.writeRegister(D_1, 1400);
+  tmc.writeRegister(VSTOP, 10);
+  tmc.writeRegister(TZEROWAIT, 0);
+  tmc.writeRegister(RAMPMODE, 0);
+
+  Serial.println("starting up");
+}
+
+// periodic delay
+uint32_t t_echo = millis();
+uint32_t t_dirchange = millis();
+bool dir = false;
+
+void loop()
+{
+  uint32_t now = millis();
+
+  // every n seconds or so...
+  if ( now - t_dirchange > 3000 )
+  {
+    t_dirchange = now;
+
+    // reverse direction
+    dir = !dir;
+    tmc.writeRegister(XTARGET, dir?(200*256):0);  // 1 full rotatation = 200s/rev * 256microsteps
+
+    digitalWrite(LED_BUILTIN, dir);
+  }
+
+  // print out current position
+  if( now - t_echo > 100 )
+  {
+    t_echo = now;
+
+    // get the current target position
+    // NB : reading out registers while they are changing is not recommended with UART interface and will probably fail.
+    // See datasheet §5.1.2
+    int32_t xactual = 0, vactual = 0;
+    xactual = tmc.readRegister(XACTUAL);
+    vactual = tmc.readRegister(VACTUAL);
+
+    Serial.print("xpos,v:");
+    Serial.print(xactual);
+    Serial.print(", ");
+    Serial.println(vactual);
+  }
+
+}

--- a/examples/back_and_forth_uart/back_and_forth_uart.ino
+++ b/examples/back_and_forth_uart/back_and_forth_uart.ino
@@ -76,7 +76,7 @@ void setup()
   pinMode(LED_BUILTIN, OUTPUT);
 
   // This sets the motor currents for HOLD & RUN, as well as the natural motor direction for positive moves
-  tmc.begin(0x4, 0x4, NORMAL_MOTOR_DIRECTION);
+  tmc.begin(4, 4, Estee_TMC5130::NORMAL_MOTOR_DIRECTION);
 
   // drive *MUST* be disabled when testing frequency scaling
   //  digitalWrite(TMC_EN, HIGH);
@@ -87,16 +87,16 @@ void setup()
 
   // ramp definition
   uint32_t onerev = 200*256;
-  tmc.writeRegister(VSTART, 0x0);
-  tmc.writeRegister(A_1, 1000);
-  tmc.writeRegister(V_1, 50000);
-  tmc.writeRegister(AMAX, 500);
-  tmc.writeRegister(VMAX, 200000);
-  tmc.writeRegister(DMAX, 700);
-  tmc.writeRegister(D_1, 1400);
-  tmc.writeRegister(VSTOP, 10);
-  tmc.writeRegister(TZEROWAIT, 0);
-  tmc.writeRegister(RAMPMODE, 0);
+  tmc.writeRegister(TMC5130_Reg::VSTART, 0x0);
+  tmc.writeRegister(TMC5130_Reg::A_1, 1000);
+  tmc.writeRegister(TMC5130_Reg::V_1, 50000);
+  tmc.writeRegister(TMC5130_Reg::AMAX, 500);
+  tmc.writeRegister(TMC5130_Reg::VMAX, 200000);
+  tmc.writeRegister(TMC5130_Reg::DMAX, 700);
+  tmc.writeRegister(TMC5130_Reg::D_1, 1400);
+  tmc.writeRegister(TMC5130_Reg::VSTOP, 10);
+  tmc.writeRegister(TMC5130_Reg::TZEROWAIT, 0);
+  tmc.writeRegister(TMC5130_Reg::RAMPMODE, TMC5130_Reg::POSITIONING_MODE);
 
   Serial.println("starting up");
 }
@@ -117,7 +117,7 @@ void loop()
 
     // reverse direction
     dir = !dir;
-    tmc.writeRegister(XTARGET, dir?(200*256):0);  // 1 full rotatation = 200s/rev * 256microsteps
+    tmc.writeRegister(TMC5130_Reg::XTARGET, dir?(200*256):0);  // 1 full rotatation = 200s/rev * 256microsteps
 
     digitalWrite(LED_BUILTIN, dir);
   }
@@ -131,8 +131,8 @@ void loop()
     // NB : reading out registers while they are changing is not recommended with UART interface and will probably fail.
     // See datasheet §5.1.2
     int32_t xactual = 0, vactual = 0;
-    xactual = tmc.readRegister(XACTUAL);
-    vactual = tmc.readRegister(VACTUAL);
+    xactual = tmc.readRegister(TMC5130_Reg::XACTUAL);
+    vactual = tmc.readRegister(TMC5130_Reg::VACTUAL);
 
     Serial.print("xpos,v:");
     Serial.print(xactual);

--- a/examples/back_and_forth_uart/back_and_forth_uart.ino
+++ b/examples/back_and_forth_uart/back_and_forth_uart.ino
@@ -124,12 +124,18 @@ void loop()
     // NB : reading out registers while they are changing is not recommended with UART interface and will probably fail.
     // See datasheet §5.1.2
     int32_t xactual = tmc.getCurrentPosition();
-    float vactual = tmc.getCurrentSpeed();
+    if (tmc.isLastReadSuccessful())
+    {
+      Serial.print("current position : ");
+      Serial.println(xactual);
+    }
 
-    Serial.print("xpos,v:");
-    Serial.print(xactual);
-    Serial.print(", ");
-    Serial.println(vactual);
+    float vactual = tmc.getCurrentSpeed();
+    if (tmc.isLastReadSuccessful())
+    {
+      Serial.print("current speed : ");
+      Serial.println(vactual);
+    }
   }
 
 }

--- a/examples/uart_chained_drivers/uart_chained_drivers.ino
+++ b/examples/uart_chained_drivers/uart_chained_drivers.ino
@@ -68,13 +68,7 @@ SOFTWARE.
 const uint8_t UART_TX_EN = 5;   // Differential transceiver TX enable pin
 const int MAX_MOTOR_COUNT = 4;
 
-//Use Serial1 (hardware UART on Feather M0) ; address 1 (NAI input has a pull up resistor)
-Estee_TMC5130_UART_Transceiver motors[MAX_MOTOR_COUNT] = {
-  Estee_TMC5130_UART_Transceiver(UART_TX_EN, Serial1, 1),
-  Estee_TMC5130_UART_Transceiver(UART_TX_EN, Serial1, 1),
-  Estee_TMC5130_UART_Transceiver(UART_TX_EN, Serial1, 1),
-  Estee_TMC5130_UART_Transceiver(UART_TX_EN, Serial1, 1)
-};
+Estee_TMC5130_UART_Transceiver motors[MAX_MOTOR_COUNT];
 int motorCount = 0;
 
 void setup()
@@ -95,6 +89,9 @@ void setup()
   bool chainEnd = false;
   while (!chainEnd && motorCount < MAX_MOTOR_COUNT)
   {
+    //Use Serial1 (hardware UART on Feather M0) ; address 1 (NAI input has a pull up resistor)
+    motors[motorCount] = Estee_TMC5130_UART_Transceiver(UART_TX_EN, Serial1, 1);
+
     //Try to query a TMC5130 at address 1 (default)
     Estee_TMC5130_UART::ReadStatus readStatus;
     uint32_t gconf = motors[motorCount].readRegister(TMC5130_Reg::GCONF, &readStatus);

--- a/examples/uart_chained_drivers/uart_chained_drivers.ino
+++ b/examples/uart_chained_drivers/uart_chained_drivers.ino
@@ -113,8 +113,7 @@ void setup()
         motors[motorCount].begin(10, 20, Estee_TMC5130::NORMAL_MOTOR_DIRECTION);
         motors[motorCount].setRampMode(Estee_TMC5130::POSITIONING_MODE);
         motors[motorCount].setMaxSpeed(200);
-        motors[motorCount].setRampSpeeds(0, 0.1, 100); //Start, stop, threshold speeds
-        motors[motorCount].setAccelerations(250, 350, 500, 700); //AMAX, DMAX, A1, D1
+        motors[motorCount].setAcceleration(500);
 
         //Turn on the bus switch to get access to the next board.
         motors[motorCount].writeRegister(TMC5130_Reg::IO_INPUT_OUTPUT, 0); //set NAO low

--- a/examples/uart_chained_drivers/uart_chained_drivers.ino
+++ b/examples/uart_chained_drivers/uart_chained_drivers.ino
@@ -1,0 +1,167 @@
+/* Multiple TMC5130 in UART mode example
+
+This code demonstrates the usage of a chain of Trinamic TMC5130 stepper drivers
+
+Hardware setup :
+A RS485 transceiver must be connected to the Serial1 pins with the TX Enable pin
+accessible to the uC
+
+Tie the A output to the TMC5130 I/O voltage with a 1k resistor (see TMC5130 datasheet
+Fig 5.2). A single resistor is needed for a chain of TMC5130.
+
+The TMC5130 Enable line must be connected to GND to enable the driver.
+
+Following TMC5130s must be connected in the same way, sharing SWP, SWN and GND.
+A strategy is necessary for differentiating the slaves at startup :
+ - either connect the first driver NAI input to GND and connect the next NAI to NAO
+ - or use a bus switch on SWP / SWN after each of the TMC5130s, triggered by NAO. For example TI TS3A4742 is a suitable chip.
+
+See TMC5130 datasheet §5.4 for details.
+This code uses the bus switch strategy with NAI left open.
+
+                                      VCC_IO
+                                      3.3/5V
+                                         +
+                                         |
+                                        +++
++-----------+        +--------------+   | | 1k     +--------------------+
+|           |        |              |   +++        |                    |
+|      RX 0 +--------+ RO           |    |         |                    |
+|           |        |            A +----+---------+ SWP_IN     SWP_OUT +----+ ++
+|           |    +---+ /RE          |              |                    |
+|   TX EN 5 +----+   |            B +--------------+ SWN_IN     SWN_OUT +----+ ++
+|           |    +---+ DE           |              |                    |
+|           |        |          GND +--------------+ GND            GND +----+ ++
+|      TX 1 +--------+ DI           |              |                    |
+|           |        |              |              |                    |
++-----------+        +--------------+              +--------------------+
+ Feather M0               MAX3485                   TMC5130 & bus switch
+                       or equivalent
+
+
+Tested on Adafruit Feather M0.
+
+Copyright (c) 2017 Tom Magnier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <Arduino.h>
+#include <Estee_TMC5130.h>
+
+const uint8_t UART_TX_EN = 5;   // Differential transceiver TX enable pin
+const int MAX_MOTOR_COUNT = 4;
+
+//Use Serial1 (hardware UART on Feather M0) ; address 1 (NAI input has a pull up resistor)
+Estee_TMC5130_UART_Transceiver motors[MAX_MOTOR_COUNT] = {
+  Estee_TMC5130_UART_Transceiver(UART_TX_EN, Serial1, 1),
+  Estee_TMC5130_UART_Transceiver(UART_TX_EN, Serial1, 1),
+  Estee_TMC5130_UART_Transceiver(UART_TX_EN, Serial1, 1),
+  Estee_TMC5130_UART_Transceiver(UART_TX_EN, Serial1, 1)
+};
+int motorCount = 0;
+
+void setup()
+{
+  // init serial coms
+  Serial.begin(9600);
+  while(!Serial);
+
+  // Init TMC serial bus @ 500kbps
+  Serial1.begin(500000);
+  Serial1.setTimeout(1); // TMC5130 should answer back immediately when reading a register.
+
+  // status LED
+  pinMode(LED_BUILTIN, OUTPUT);
+
+  // TMC5130 research on bus
+  Serial.println("Starting to look for TMC5130.\n");
+  bool chainEnd = false;
+  while (!chainEnd && motorCount < MAX_MOTOR_COUNT)
+  {
+    //Try to query a TMC5130 at address 1 (default)
+    Estee_TMC5130_UART::ReadStatus readStatus;
+    uint32_t gconf = motors[motorCount].readRegister(TMC5130_Reg::GCONF, &readStatus);
+
+    switch (readStatus)
+    {
+      case Estee_TMC5130_UART::SUCCESS:
+      {
+        Serial.println("Found TMC5130 @ address 1.");
+
+        //Addressing
+        uint8_t address = 254-motorCount;
+        motors[motorCount].setSlaveAddress(address, true);
+        Serial.print("New address : ");
+        Serial.println(address);
+        Serial.println();
+
+        //Motor init
+        motors[motorCount].begin(10, 20, Estee_TMC5130::NORMAL_MOTOR_DIRECTION);
+        motors[motorCount].setRampMode(Estee_TMC5130::POSITIONING_MODE);
+        motors[motorCount].setMaxSpeed(200);
+        motors[motorCount].setRampSpeeds(0, 0.1, 100); //Start, stop, threshold speeds
+        motors[motorCount].setAccelerations(250, 350, 500, 700); //AMAX, DMAX, A1, D1
+
+        //Turn on the bus switch to get access to the next board.
+        motors[motorCount].writeRegister(TMC5130_Reg::IO_INPUT_OUTPUT, 0); //set NAO low
+        motors[motorCount].resetCommunication();
+        motorCount++;
+      }
+      break;
+
+      case Estee_TMC5130_UART::NO_REPLY:
+      Serial.println("No more TMC5130 found.");
+      chainEnd = true;
+      break;
+
+      case Estee_TMC5130_UART::BAD_CRC:
+      Serial.println("A TMC5130 replied with a bad CRC. Trying again."); //TODO keep a count of failed attempts.
+      motors[motorCount].resetCommunication();
+      break;
+    }
+  }
+
+  Serial.println("Starting up");
+}
+
+// periodic delay
+uint32_t t_echo = millis();
+uint32_t t_dirchange = millis();
+bool dir = false;
+
+void loop()
+{
+  uint32_t now = millis();
+
+  // every n seconds or so...
+  if ( now - t_dirchange > 8000 )
+  {
+    t_dirchange = now;
+
+    // reverse direction
+    dir = !dir;
+    for (int i = 0; i < motorCount; i++)
+    {
+      motors[i].setTargetPosition(dir ? 200 * (i+1) : 0);  // 1 full rotation = 200s/rev
+    }
+
+    digitalWrite(LED_BUILTIN, dir);
+  }
+}

--- a/examples/uart_reliable_mode/uart_reliable_mode.ino
+++ b/examples/uart_reliable_mode/uart_reliable_mode.ino
@@ -84,8 +84,7 @@ void setup()
   // ramp definition
   tmc.setRampMode(Estee_TMC5130_UART::POSITIONING_MODE);
   tmc.setMaxSpeed(200);
-  tmc.setRampSpeeds(0, 0.1, 100); //Start, stop, threshold speeds
-  tmc.setAccelerations(250, 350, 500, 700); //AMAX, DMAX, A1, D1
+  tmc.setAcceleration(500);
 
   //Switch to streaming mode to send target positions at repeated intervals
   tmc.setCommunicationMode(Estee_TMC5130_UART::STREAMING_MODE);

--- a/examples/uart_reliable_mode/uart_reliable_mode.ino
+++ b/examples/uart_reliable_mode/uart_reliable_mode.ino
@@ -1,0 +1,103 @@
+/* TMC5130 UART example
+
+This code demonstrates the usage of the reliable vs. streaming modes
+when driving a Trinamic TMC5130 stepper driver using its single-wire interface.
+
+Hardware setup :
+A RS485 transceiver must be connected to the Serial1 pins with the TX Enable pin
+accessible to the uC
+
+Tie the A output to the TMC5130 I/O voltage with a 1k resistor (see TMC5130 datasheet
+Fig 5.2)
+
+The TMC5130 Enable line must be connected to GND to enable the driver.
+
+                                                3.3/5V
+                                                  +     +-----------------+
+                                            +-----+---+-+ VCC_IO          |
+                                            |         | |                 |
+                                           +++        | |                 |
++-----------+        +--------------+      | | 1k     +-+ SWSEL           |
+|           |        |              |      +++          |                 |
+|      RX 0 +--------+ RO           |       |           |                 |
+|           |        |            A +-------+-----------+ SWP         NAI ++ open
+|           |    +---+ /RE          |                   |                 |
+|   TX EN 5 +----+   |            B +-------------------+ SWN             |
+|           |    +---+ DE           |                   |                 |
+|           |        |          GND +----+         +----+ DRV_ENN         |
+|      TX 1 +--------+ DI           |    |         |    |                 |
+|           |        |              |    +---------+----+ GND             |
++-----------+        +--------------+                   +-----------------+
+ Feather M0               MAX3485                              TMC5130
+                       or equivalent
+
+
+Tested on Adafruit Feather M0 / Teensy 3.x
+
+Copyright (c) 2017 Tom Magnier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <Arduino.h>
+#include <Estee_TMC5130.h>
+
+const uint8_t UART_TX_EN = 5;   // Differential transceiver TX enable pin
+
+Estee_TMC5130_UART_Transceiver tmc = Estee_TMC5130_UART_Transceiver(UART_TX_EN, Serial1, 1); //Use Serial1 (hardware UART on Feather M0) ; address 1 (NAI input has a pull up resistor)
+
+void setup()
+{
+  // init serial coms
+  Serial.begin(9600);
+  while (!Serial); //Wait for serial monitor opening on USB boards
+
+  // Init TMC serial bus @ 500kbps
+  Serial1.begin(500000);
+  Serial1.setTimeout(1); // TMC5130 should answer back immediately when reading a register.
+
+  // status LED
+  pinMode(LED_BUILTIN, OUTPUT);
+
+  //Use reliable mode for initialization to make sure that no commands are skipped
+  tmc.setCommunicationMode(Estee_TMC5130_UART::RELIABLE_MODE);
+
+  // This sets the motor currents for HOLD & RUN, as well as the natural motor direction for positive moves
+  tmc.begin(10, 20, Estee_TMC5130::NORMAL_MOTOR_DIRECTION);
+
+  // ramp definition
+  tmc.setRampMode(Estee_TMC5130_UART::POSITIONING_MODE);
+  tmc.setMaxSpeed(200);
+  tmc.setRampSpeeds(0, 0.1, 100); //Start, stop, threshold speeds
+  tmc.setAccelerations(250, 350, 500, 700); //AMAX, DMAX, A1, D1
+
+  //Switch to streaming mode to send target positions at repeated intervals
+  tmc.setCommunicationMode(Estee_TMC5130_UART::STREAMING_MODE);
+
+  Serial.println("starting up");
+}
+
+void loop()
+{
+  //Sinusoidal movement
+  float period_ms = 5000;
+  int amplitude = 100;
+  tmc.setTargetPosition(sin(2 * PI * millis() / period_ms) * amplitude);
+  delay(5);
+}

--- a/examples/uart_reliable_mode/uart_reliable_mode.ino
+++ b/examples/uart_reliable_mode/uart_reliable_mode.ino
@@ -90,7 +90,15 @@ void setup()
   //Switch to streaming mode to send target positions at repeated intervals
   tmc.setCommunicationMode(Estee_TMC5130_UART::STREAMING_MODE);
 
-  Serial.println("starting up");
+  Serial.print("Write success rate : ");
+  Serial.print(tmc.getWriteSuccessRate() * 100.0);
+  Serial.println("%");
+
+  Serial.print("Read success rate : ");
+  Serial.print(tmc.getReadSuccessRate() * 100.0);
+  Serial.println("%");
+
+  Serial.println("Starting up");
 }
 
 void loop()

--- a/examples/velocity_mode_uart/velocity_mode_uart.ino
+++ b/examples/velocity_mode_uart/velocity_mode_uart.ino
@@ -1,0 +1,133 @@
+/* TMC5130 Velocity mode example
+
+This code demonstrates the usage of a Trinamic TMC5130 stepper driver in velocity mode, using its
+single-wire interface.
+
+Hardware setup :
+A RS485 transceiver must be connected to the Serial1 pins with the TX Enable pin
+accessible to the uC
+
+Tie the A output to the TMC5130 I/O voltage with a 1k resistor (see TMC5130 datasheet
+Fig 5.2)
+
+The TMC5130 Enable line must be connected to GND to enable the driver.
+
+                                                3.3/5V
+                                                  +     +-----------------+
+                                            +-----+---+-+ VCC_IO          |
+                                            |         | |                 |
+                                           +++        | |                 |
++-----------+        +--------------+      | | 1k     +-+ SWSEL           |
+|           |        |              |      +++          |                 |
+|      RX 0 +--------+ RO           |       |           |                 |
+|           |        |            A +-------+-----------+ SWP         NAI ++ open
+|           |    +---+ /RE          |                   |                 |
+|   TX EN 5 +----+   |            B +-------------------+ SWN             |
+|           |    +---+ DE           |                   |                 |
+|           |        |          GND +----+         +----+ DRV_ENN         |
+|      TX 1 +--------+ DI           |    |         |    |                 |
+|           |        |              |    +---------+----+ GND             |
++-----------+        +--------------+                   +-----------------+
+ Feather M0               MAX3485                              TMC5130
+                       or equivalent
+
+
+Tested on Adafruit Feather M0.
+
+Copyright (c) 2017 Tom Magnier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <Arduino.h>
+#include <Estee_TMC5130.h>
+
+const uint8_t UART_TX_EN = 5;   // Differential transceiver TX enable pin
+
+Estee_TMC5130_UART_Transceiver tmc = Estee_TMC5130_UART_Transceiver(UART_TX_EN, Serial1, 1); //Use Serial1 (hardware UART on Feather M0) ; address 1 (NAI input has a pull up resistor)
+
+void setup()
+{
+  // init serial coms
+  Serial.begin(9600);
+  //while (!Serial); //Wait for serial monitor opening on USB boards
+
+  // Init TMC serial bus @ 250kbps
+  Serial1.begin(250000);
+  Serial1.setTimeout(5); // TMC5130 should answer back immediately when reading a register.
+
+  // status LED
+  pinMode(LED_BUILTIN, OUTPUT);
+
+  // This sets the motor currents for HOLD & RUN, as well as the natural motor direction for positive moves
+  tmc.begin(4, 4, Estee_TMC5130::NORMAL_MOTOR_DIRECTION);
+
+  // drive *MUST* be disabled when testing frequency scaling
+  //  digitalWrite(TMC_EN, HIGH);
+  //  float freq = tmc.updateFrequencyScaling();
+  //  Serial.print("frequency scaling: ");
+  //  Serial.println(freq);
+  //  delay(5000);
+
+  // ramp definition
+  tmc.setRampMode(Estee_TMC5130::VELOCITY_MODE);
+  tmc.setAccelerations(1000, 0, 0, 0); //AMAX, DMAX, A1, D1. Only AMAX is used in velocity mode.
+
+  Serial.println("starting up");
+}
+
+// periodic delay
+uint32_t t_echo = millis();
+uint32_t t_dirchange = millis();
+bool dir = false;
+
+void loop()
+{
+  uint32_t now = millis();
+
+  // every n seconds or so...
+  if ( now - t_dirchange > 3000 )
+  {
+    t_dirchange = now;
+
+    // reverse direction
+    dir = !dir;
+    tmc.setMaxSpeed(dir ? 500 : -500);
+
+    digitalWrite(LED_BUILTIN, dir);
+  }
+
+  // print out current position
+  if( now - t_echo > 100 )
+  {
+    t_echo = now;
+
+    // get the current target position
+    // NB : reading out registers while they are changing is not recommended with UART interface and will probably fail.
+    // See datasheet §5.1.2
+    int32_t xactual = tmc.getCurrentPosition();
+    float vactual = tmc.getCurrentSpeed();
+
+    Serial.print("xpos,v:");
+    Serial.print(xactual);
+    Serial.print(", ");
+    Serial.println(vactual);
+  }
+
+}

--- a/examples/velocity_mode_uart/velocity_mode_uart.ino
+++ b/examples/velocity_mode_uart/velocity_mode_uart.ino
@@ -87,7 +87,7 @@ void setup()
 
   // ramp definition
   tmc.setRampMode(Estee_TMC5130::VELOCITY_MODE);
-  tmc.setAccelerations(1000, 0, 0, 0); //AMAX, DMAX, A1, D1. Only AMAX is used in velocity mode.
+  tmc.setAcceleration(1000);
 
   Serial.println("starting up");
 }

--- a/examples/velocity_mode_uart/velocity_mode_uart.ino
+++ b/examples/velocity_mode_uart/velocity_mode_uart.ino
@@ -122,12 +122,18 @@ void loop()
     // NB : reading out registers while they are changing is not recommended with UART interface and will probably fail.
     // See datasheet §5.1.2
     int32_t xactual = tmc.getCurrentPosition();
-    float vactual = tmc.getCurrentSpeed();
+    if (tmc.isLastReadSuccessful())
+    {
+      Serial.print("current position : ");
+      Serial.println(xactual);
+    }
 
-    Serial.print("xpos,v:");
-    Serial.print(xactual);
-    Serial.print(", ");
-    Serial.println(vactual);
+    float vactual = tmc.getCurrentSpeed();
+    if (tmc.isLastReadSuccessful())
+    {
+      Serial.print("current speed : ");
+      Serial.println(vactual);
+    }
   }
 
 }

--- a/util/Bitfield.h
+++ b/util/Bitfield.h
@@ -50,6 +50,7 @@ public:
     T operator++(int)              { T r = *this; ++*this; return r; }
     BitField &operator--()         { return *this = *this - 1; }
     T operator--(int)              { T r = *this; --*this; return r; }
+    size_t size() const            { return Bits; }
 
 private:
     T value_;

--- a/util/Bitfield.h
+++ b/util/Bitfield.h
@@ -1,0 +1,80 @@
+/* From https://blog.codef00.com/2014/12/06/portable-bitfields-using-c11/
+ * No license defined.
+ */
+
+#ifndef BITFIELD_H_
+#define BITFIELD_H_
+
+#include <stdint.h>
+#include <stddef.h>
+#include "type_traits.h"
+
+// using std::uint8_t;
+// using std::uint16_t;
+// using std::uint32_t;
+// using std::uint64_t;
+
+namespace {
+
+template <size_t LastBit>
+struct MinimumTypeHelper {
+    typedef
+        typename std::conditional<LastBit == 0 , void,
+        typename std::conditional<LastBit <= 8 , uint8_t,
+        typename std::conditional<LastBit <= 16, uint16_t,
+        typename std::conditional<LastBit <= 32, uint32_t,
+        typename std::conditional<LastBit <= 64, uint64_t,
+        void>::type>::type>::type>::type>::type type;
+};
+
+}
+
+template <size_t Index, size_t Bits = 1>
+class BitField {
+private:
+    enum {
+        Mask = (1u << Bits) - 1u
+    };
+
+    typedef typename MinimumTypeHelper<Index + Bits>::type T;
+public:
+    template <class T2>
+    BitField &operator=(T2 value) {
+        value_ = (value_ & ~(Mask << Index)) | ((value & Mask) << Index);
+        return *this;
+    }
+
+    operator T() const             { return (value_ >> Index) & Mask; }
+    explicit operator bool() const { return value_ & (Mask << Index); }
+    BitField &operator++()         { return *this = *this + 1; }
+    T operator++(int)              { T r = *this; ++*this; return r; }
+    BitField &operator--()         { return *this = *this - 1; }
+    T operator--(int)              { T r = *this; --*this; return r; }
+
+private:
+    T value_;
+};
+
+
+template <size_t Index>
+class BitField<Index, 1> {
+private:
+    enum {
+        Bits = 1,
+        Mask = 0x01
+    };
+
+    typedef typename MinimumTypeHelper<Index + Bits>::type T;
+public:
+    BitField &operator=(bool value) {
+        value_ = (value_ & ~(Mask << Index)) | (value << Index);
+        return *this;
+    }
+
+    explicit operator bool() const { return value_ & (Mask << Index); }
+
+private:
+    T value_;
+};
+
+#endif

--- a/util/Bitfield.h
+++ b/util/Bitfield.h
@@ -40,12 +40,12 @@ private:
 public:
     template <class T2>
     BitField &operator=(T2 value) {
-        value_ = (value_ & ~(Mask << Index)) | ((value & Mask) << Index);
+        value_ = (value_ & ~((T)Mask << Index)) | (((T)value & (T)Mask) << Index);
         return *this;
     }
 
-    operator T() const             { return (value_ >> Index) & Mask; }
-    explicit operator bool() const { return value_ & (Mask << Index); }
+    operator T() const             { return (value_ >> Index) & (T)Mask; }
+    explicit operator bool() const { return value_ & ((T)Mask << Index); }
     BitField &operator++()         { return *this = *this + 1; }
     T operator++(int)              { T r = *this; ++*this; return r; }
     BitField &operator--()         { return *this = *this - 1; }
@@ -68,11 +68,11 @@ private:
     typedef typename MinimumTypeHelper<Index + Bits>::type T;
 public:
     BitField &operator=(bool value) {
-        value_ = (value_ & ~(Mask << Index)) | (value << Index);
+        value_ = (value_ & ~((T)Mask << Index)) | ((T)value << Index);
         return *this;
     }
 
-    explicit operator bool() const { return value_ & (Mask << Index); }
+    explicit operator bool() const { return value_ & ((T)Mask << Index); }
 
 private:
     T value_;

--- a/util/type_traits.h
+++ b/util/type_traits.h
@@ -1,0 +1,31 @@
+// From http://close2.github.io/alibvr/doxygen/html/df/d63/type__traits_8h_source.html
+
+#pragma once
+
+namespace std {
+
+  template<class T, T v>
+  struct integral_constant {
+      static constexpr T value = v;
+      typedef T value_type;
+      typedef integral_constant type;
+      constexpr operator value_type() const noexcept { return value; }
+      constexpr value_type operator()() const noexcept { return value; }
+  };
+
+  typedef std::integral_constant<bool, true> true_type;
+  typedef std::integral_constant<bool, false> false_type;
+
+  template<class T, class U>
+  struct is_same : false_type {};
+
+  template<class T>
+  struct is_same<T, T> : true_type {};
+
+
+  template<bool B, class T, class F>
+  struct conditional { typedef T type; };
+
+  template<class T, class F>
+  struct conditional<false, T, F> { typedef F type; };
+}


### PR DESCRIPTION
Hello Mike, 

Here are some additions to your TMC5130 code which helped me a lot to get started with this chip !
The library now comes with :
- UART support (tested with multiple drivers)
- higher level ramp control with speeds in steps/s and accelerations in steps/s^2
- complete register definitions

The API had to change a little to accomodate for these changes but existing code should still work with minor modifications. 

Planned additions:
- at the moment the positions are specified in full steps. Maybe a new function like `setPositionResolution()` could be added for applications needing microstep positioning. 
- in UART mode it could be interesting to have "safe" write and reads (check the transmission counter after writing, multiple retries in case of bad CRC after reading). 

Also, what do you think about renaming the classes to TMC5130, TMC5130_SPI, etc. ? The class names are becoming rather verbose... 

Let me know if you think that these changes should not be merged because of the API break or if you prefer to merge them later.

Thanks again for sharing the initial code :)

Cheers,
Tom